### PR TITLE
feat: UX Credibility Redesign — Trust & Clarity Components

### DIFF
--- a/docs/DATA_PIPELINE.md
+++ b/docs/DATA_PIPELINE.md
@@ -1,0 +1,296 @@
+# Data Pipeline Architecture
+
+> How reps.arialabs.ai gets its data — and how every score is calculated.
+
+## Overview
+
+The accountability dashboard uses **exclusively real data** from authoritative government sources. No scores are fabricated. Every number traces back to a public API or official record.
+
+### Data Sources
+
+| Source | What We Get | API | Update Frequency |
+|--------|------------|-----|-----------------|
+| **Congress.gov** | Members, bills, vote records, committees | `api.congress.gov/v3` | Weekly |
+| **Voteview (UCLA)** | Ideology scores (DW-NOMINATE), party loyalty | CSV download | Weekly |
+| **OpenFEC** | Campaign finance, donors, PAC money | `api.open.fec.gov/v1` | Weekly |
+| **OnTheIssues.org** | Stated policy positions | Web scrape | Monthly |
+
+### Pipeline Steps
+
+```
+┌─────────────┐    ┌──────────────┐    ┌─────────────┐    ┌──────────────┐
+│ Congress.gov │───▶│ Members +    │───▶│ Enrich with │───▶│ Compute      │
+│ API          │    │ Committees   │    │ Voteview +   │    │ Alignment    │
+└─────────────┘    └──────────────┘    │ FEC data     │    │ Scores       │
+                                       └─────────────┘    └──────────────┘
+                                              │                    │
+                                              ▼                    ▼
+                                       ┌─────────────┐    ┌──────────────┐
+                                       │ src/data/    │    │ src/data/    │
+                                       │ members.json │    │ alignment-   │
+                                       │ finance.json │    │ scores.json  │
+                                       └─────────────┘    └──────────────┘
+```
+
+---
+
+## Data Models
+
+### Member (from Congress.gov + Voteview)
+
+```typescript
+{
+  bioguide_id: string;       // Unique ID from Congress.gov
+  full_name: string;
+  party: "D" | "R" | "I";
+  state: string;
+  district: number | null;   // null for senators
+  chamber: "house" | "senate";
+  photo_url: string;
+  bills_sponsored: number;   // From Congress.gov
+  bills_cosponsored: number; // From Congress.gov
+  committees: Committee[];   // From Congress.gov
+  party_loyalty_pct: number; // From Voteview (% votes with party)
+  ideology_score: number;    // DW-NOMINATE dim1 (-1 liberal to +1 conservative)
+  votes_cast: number;        // From Voteview
+}
+```
+
+### Campaign Finance (from OpenFEC)
+
+```typescript
+{
+  candidate_id: string;      // FEC candidate ID
+  cycle: number;             // Election cycle (e.g., 2024)
+  total_raised: number;
+  total_spent: number;
+  individual_contributions: number;
+  pac_contributions: number;
+  small_donors: number;      // ≤$200 (unitemized)
+  large_donors: number;      // >$200 (itemized)
+  pac_percentage: number;    // pac_contributions / total_raised * 100
+  top_contributors: [{
+    name: string;
+    total: number;
+    type: "individual" | "pac" | "party";
+  }];
+  top_industries: [{
+    industry: string;
+    total: number;
+  }];
+}
+```
+
+### Alignment Score (Computed)
+
+```typescript
+{
+  bioguide_id: string;
+  alignment_score: number;           // 0-100
+  total_votes_analyzed: number;
+  aligned_votes: number;
+  misaligned_votes: number;
+  category_breakdown: {
+    [category: string]: {
+      aligned: number;
+      total: number;
+      score: number;
+    }
+  };
+  notable_misalignments: [{
+    bill_id: string;
+    bill_title: string;
+    stated_position: string;
+    actual_vote: string;
+    category: string;
+  }];
+  methodology_version: string;       // e.g., "2.0"
+  last_computed: string;             // ISO timestamp
+}
+```
+
+---
+
+## Score Calculation Methodology (v2.0)
+
+### "Say vs. Do" Alignment Score
+
+This is the core metric. It measures whether a member's **actual votes** align with their **stated positions**.
+
+#### Inputs
+
+1. **Stated Positions** — From OnTheIssues.org, which aggregates:
+   - Campaign website statements
+   - Floor speeches
+   - Press releases
+   - Interview quotes
+   - Previous voting record summaries
+   
+   Each position has a `topic`, `stance` (Strongly Supports → Strongly Opposes), and `intensity` (1-5).
+
+2. **Actual Votes** — From Congress.gov roll call votes on key bills. Each bill is categorized by topic.
+
+3. **Campaign Finance Context** — From OpenFEC. Used as a transparency flag, not a score input.
+
+#### Algorithm
+
+```
+For each member:
+  1. Get their stated positions (P) from OnTheIssues
+  2. Get their vote records (V) from Congress.gov
+  3. For each vote V[i]:
+     a. Map the bill's category to a position topic
+     b. Determine if the vote ALIGNS with or CONTRADICTS the stated position
+        - Position says "Supports X" + Vote is "Yea" on pro-X bill → ALIGNED
+        - Position says "Supports X" + Vote is "Nay" on pro-X bill → MISALIGNED
+        - Position says "Opposes X" + Vote is "Yea" on pro-X bill → MISALIGNED
+        - Position says "Opposes X" + Vote is "Nay" on pro-X bill → ALIGNED
+     c. Record the alignment/misalignment
+  4. alignment_score = (aligned_votes / total_votes_analyzed) * 100
+  5. Break down by category for transparency
+```
+
+#### Bill-to-Position Mapping
+
+Bills are manually categorized into topics that map to OnTheIssues positions:
+
+| Bill Category | OnTheIssues Topic |
+|--------------|-------------------|
+| Healthcare/ACA | "Expand ObamaCare" |
+| Climate/Environment | "Prioritize green energy" |
+| Gun Control | "Gun Control" |
+| Immigration | "Immigration" |
+| Defense Spending | "Make military spending" |
+| Tax Policy | "Higher taxes on the wealthy" |
+| Abortion | "Abortion is a woman's unrestricted right" |
+| Education | "Vouchers for school choice" |
+
+#### What Counts as a "Key Vote"
+
+Not every procedural vote is analyzed. We focus on:
+- Final passage votes on major legislation
+- Amendment votes on contentious provisions
+- Cloture votes on significant bills (Senate)
+- Veto override attempts
+
+#### Edge Cases
+
+- **New members** (< 5 votes analyzed): Score shown with "limited data" badge
+- **Missing positions**: If no OnTheIssues data, member is excluded from alignment scoring
+- **Not Voting / Abstain**: Excluded from calculation (neither aligned nor misaligned)
+- **No matching position**: If a bill doesn't map to any stated position, it's excluded
+
+#### Confidence Indicator
+
+```
+votes_analyzed >= 50  → High confidence
+votes_analyzed >= 20  → Medium confidence  
+votes_analyzed >= 5   → Low confidence
+votes_analyzed < 5    → Insufficient data (score not displayed)
+```
+
+### Red Flags (Transparency Indicators)
+
+Red flags are NOT subjective judgments. They're factual indicators:
+
+1. **High PAC Dependency** — PAC contributions > 50% of total raised
+2. **Donor-Vote Alignment** — Voted in favor of legislation benefiting top 10 donors/industries
+3. **Low Disclosure Compliance** — Late or incomplete financial disclosures
+4. **Committee-Related Trading** — Stock trades in companies under member's committee jurisdiction
+
+Each flag includes the raw data so users can judge for themselves.
+
+---
+
+## API Endpoints Used
+
+### Congress.gov (`api.congress.gov/v3`)
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /member?currentMember=true&limit=250` | All current members |
+| `GET /member/{bioguide_id}` | Member detail (bills sponsored/cosponsored) |
+| `GET /bill/{congress}/{type}/{number}` | Bill details |
+| `GET /bill/{congress}/{type}/{number}/actions` | Bill action history |
+
+**Rate Limit**: 5,000 requests/hour (with API key)
+
+### OpenFEC (`api.open.fec.gov/v1`)
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /candidates/search` | Find FEC candidate ID from name/state |
+| `GET /candidate/{id}/totals` | Financial summary |
+| `GET /schedules/schedule_a` | Individual contributions (itemized) |
+| `GET /schedules/schedule_b` | Disbursements |
+
+**Rate Limit**: 1,000 requests/hour (with API key)
+
+### Voteview (UCLA)
+
+| Resource | Purpose |
+|----------|---------|
+| `voteview.com/static/data/out/members/HSall_members.csv` | All member ideology scores |
+| `voteview.com/static/data/out/rollcalls/` | Roll call vote data |
+
+**Rate Limit**: None (static CSV files)
+
+---
+
+## Storage Approach
+
+**JSON files in `src/data/`** — imported statically by Next.js at build time.
+
+Why JSON files instead of a database:
+- Zero runtime dependencies
+- Instant page loads (data baked into static HTML)
+- Git-tracked — every data change is auditable
+- Simple deployment (Cloudflare Pages)
+
+Files:
+- `members.json` — All 535 members with basic data
+- `finance.json` — Campaign finance keyed by bioguide_id
+- `committees.json` — Committee assignments
+- `alignment-scores.json` — Computed Say vs. Do scores
+- `alignment-summary.json` — Sorted summary for leaderboard
+- `positions.json` — Stated positions from OnTheIssues
+- `key-votes.json` — Key bill votes with member roll calls
+
+---
+
+## Update Schedule
+
+| Data | Frequency | Trigger |
+|------|-----------|---------|
+| Members | Weekly | Cron (Sunday 2am ET) |
+| Votes | Weekly | Cron (Sunday 2am ET) |
+| Finance | Weekly | Cron (Sunday 2am ET) |
+| Alignment Scores | Weekly | After votes + positions update |
+| Positions | Monthly | Manual trigger |
+
+Pipeline runs via GitHub Actions or local `pnpm pipeline`.
+
+---
+
+## Running the Pipeline
+
+```bash
+# Full pipeline
+CONGRESS_API_KEY=xxx FEC_API_KEY=xxx pnpm pipeline
+
+# Individual steps
+CONGRESS_API_KEY=xxx pnpm pipeline:members
+FEC_API_KEY=xxx tsx scripts/fetch-finance.ts
+tsx scripts/fetch-votes.ts
+tsx scripts/compute-scores.ts
+```
+
+---
+
+## Transparency Commitment
+
+1. **Every score shows its math** — Click any alignment score to see which votes contributed
+2. **Every data point cites its source** — API endpoint, date fetched, raw values
+3. **Methodology is versioned** — Changes to scoring are documented with version bumps
+4. **Data is git-tracked** — Anyone can see exactly when data changed and why
+5. **No editorial judgment** — We present facts; users draw conclusions

--- a/docs/UX_IMPROVEMENTS.md
+++ b/docs/UX_IMPROVEMENTS.md
@@ -1,0 +1,145 @@
+# UX Improvements: Trust & Credibility Redesign
+
+**Date:** February 13, 2026  
+**Goal:** Make every data point feel verifiable, understandable, and trustworthy within 5 seconds.
+
+---
+
+## 1. Homepage / Say vs. Do Leaderboard
+
+### Score Display — Immediate Comprehension
+**Problem:** "85%" is meaningless without context. Users ask: "85% of what?"
+
+**Solution:** Replace bare percentages with contextual score cards:
+
+```
+┌──────────────────────────────────────┐
+│  Rep. Jane Smith         Score: 85%  │
+│  ████████████████░░░░                │
+│  "Compared 12 public statements      │
+│   against 47 votes on related bills" │
+│  ─────────────────────────────────── │
+│  📊 How is this calculated?          │
+│  🕐 Last updated: Feb 13, 2026      │
+└──────────────────────────────────────┘
+```
+
+**Key changes:**
+- Below every score: "Based on X statements vs Y votes"
+- Inline "How is this calculated?" link → `/methodology`
+- Color meaning is explicit: 🟢 70%+ = Votes match words | 🟡 50-69% = Mixed | 🔴 <50% = Says one thing, does another
+- Never show a score without showing the sample size
+
+### Data Freshness
+- Every leaderboard shows: "Data from Congress.gov & OnTheIssues · Updated Feb 13, 2026"
+- Stale data (>30 days) gets a ⚠️ warning badge
+
+### Filters & Sort
+- **Party:** D / R / I toggle (already exists as chamber filter — extend)
+- **State:** Dropdown with search
+- **Score range:** Slider (0-100%)
+- **Chamber:** House / Senate / All (exists)
+- **Sort by:** Score (high→low, low→high), Name, State
+
+---
+
+## 2. Individual Representative Pages
+
+### Score Breakdown — Show the Math
+**Problem:** A single number hides important nuance.
+
+**Solution:** `ScoreExplainer` component showing:
+1. **Overall score** with confidence indicator (dots: ● ● ● ○ ○)
+2. **Factor breakdown** — weighted bar chart (already exists in `ScoreBreakdownModal`, promote to inline)
+3. **Sample size warning** when data is thin
+4. **"View all X votes analyzed"** expandable section
+
+### Statement vs Vote Comparison
+**The killer feature for trust.** Side-by-side cards:
+
+```
+┌─────────────────────┬──────────────────────┐
+│  📢 THEY SAID       │  🗳️ THEY VOTED       │
+│                     │                      │
+│  "I will always     │  Voted NO on         │
+│   protect Social    │  HR 4521: Social     │
+│   Security"         │  Security Protection │
+│   — Campaign, 2024  │  Act (Jan 15, 2026)  │
+│                     │                      │
+│  Source: OnTheIssues │  Source: Congress.gov │
+│  ↗ View original    │  ↗ View roll call    │
+└─────────────────────┴──────────────────────┘
+│  ⚠️ MISALIGNED — Said they'd protect it, voted against it
+└────────────────────────────────────────────────
+```
+
+### Vote History Timeline
+- Chronological list with verdict badges (Yea/Nay/Not Voting)
+- Filter by category (Healthcare, Defense, Economy, etc.)
+- Each vote links to Congress.gov roll call
+
+### Campaign Finance
+- Donut chart: PAC vs Individual vs Small Dollar
+- "Top 5 Industries" bar chart
+- Correlation callout: "Received $X from [Industry] → Voted [for/against] [Industry Bill]"
+
+---
+
+## 3. Trust Indicators (Site-Wide)
+
+### `DataSourceBadge` — On Every Data Point
+Small inline badge: `📄 Congress.gov` or `💰 OpenFEC` or `📰 OnTheIssues`
+- Clickable → opens source in new tab
+- Tooltip shows: "Retrieved [date] from [full URL]"
+
+### Methodology Page (`/methodology`)
+Full transparency page covering:
+1. What data sources we use (Congress.gov API, OpenFEC, OnTheIssues)
+2. How alignment scores are calculated (weighted factors, time decay)
+3. Known limitations (position data gaps, vote categorization challenges)
+4. Confidence scoring explained
+5. Changelog: version history of scoring algorithm
+6. "Disagree? File an issue" → GitHub link
+
+### Attribution Footer (Site-Wide)
+```
+Data sourced from: Congress.gov · OpenFEC · OnTheIssues.org
+Scoring methodology v1.2 · Last updated Feb 13, 2026
+Open source: github.com/jeremyspofford/accountability-dashboard
+```
+
+### Timestamps
+- Every data card: "Updated [relative time]" (e.g., "2 days ago")
+- Hover for absolute: "February 11, 2026 at 3:42 PM EST"
+
+---
+
+## 4. New Components
+
+| Component | Purpose | Location |
+|-----------|---------|----------|
+| `ScoreExplainer` | Inline score breakdown with context | Rep pages, leaderboard hover |
+| `DataSourceBadge` | Attribution badge for any data point | Everywhere |
+| `MethodologyPage` | Full scoring transparency | `/methodology` |
+| `VoteComparisonCard` | Statement vs vote side-by-side | Rep pages |
+
+---
+
+## 5. Design Principles
+
+1. **No number without context** — Every stat shows what it measures and sample size
+2. **No claim without source** — Every data point links to its origin
+3. **No score without explanation** — Users can always drill into the math
+4. **Freshness is visible** — Users know when data was last updated
+5. **Uncertainty is honest** — Low-confidence scores are flagged, not hidden
+
+---
+
+## 6. Implementation Priority
+
+1. **P0:** `DataSourceBadge` + attribution footer (quick wins, huge trust boost)
+2. **P0:** `VoteComparisonCard` (the "aha moment" for users)
+3. **P1:** `ScoreExplainer` inline version (promote existing modal content)
+4. **P1:** `/methodology` page
+5. **P2:** Filters/sort on leaderboard
+6. **P2:** Campaign finance correlation callouts

--- a/scripts/fetch-members.ts
+++ b/scripts/fetch-members.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env tsx
+/**
+ * Fetch all current members of Congress from Congress.gov API
+ * 
+ * Usage: CONGRESS_API_KEY=xxx tsx scripts/fetch-members.ts
+ * 
+ * Output: src/data/members.json
+ * Source: https://api.congress.gov/v3
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const API_BASE = "https://api.congress.gov/v3";
+const API_KEY = process.env.CONGRESS_API_KEY;
+const OUTPUT_PATH = path.join(__dirname, "../src/data/members.json");
+
+if (!API_KEY) {
+  console.error("❌ CONGRESS_API_KEY required. Get one at https://api.congress.gov/sign-up/");
+  process.exit(1);
+}
+
+interface RawMember {
+  bioguideId: string;
+  name: string;
+  partyName: string;
+  state: string;
+  district?: number;
+  depiction?: { imageUrl: string };
+  terms: { item: Array<{ chamber: string; startYear: number; endYear?: number }> };
+  url: string;
+  sponsoredLegislation?: { count: number };
+  cosponsoredLegislation?: { count: number };
+}
+
+async function fetchWithRetry(url: string, retries = 3): Promise<any> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.status === 429) {
+        const wait = Math.pow(2, i) * 2000;
+        console.log(`  Rate limited, waiting ${wait}ms...`);
+        await new Promise(r => setTimeout(r, wait));
+        continue;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      return await res.json();
+    } catch (e) {
+      if (i === retries - 1) throw e;
+      await new Promise(r => setTimeout(r, 1000 * (i + 1)));
+    }
+  }
+}
+
+function parseName(fullName: string): { first: string; last: string } {
+  // Congress.gov format: "Last, First" or "Last, First Middle"
+  const parts = fullName.split(", ");
+  if (parts.length >= 2) {
+    return { last: parts[0].trim(), first: parts[1].trim().split(" ")[0] };
+  }
+  const words = fullName.split(" ");
+  return { first: words[0], last: words[words.length - 1] };
+}
+
+function mapParty(partyName: string): string {
+  if (partyName.startsWith("Democrat")) return "D";
+  if (partyName.startsWith("Republican")) return "R";
+  if (partyName.startsWith("Independent")) return "I";
+  return partyName.charAt(0);
+}
+
+function getCurrentChamber(terms: RawMember["terms"]): "house" | "senate" {
+  const items = terms?.item || [];
+  const current = items.find(t => !t.endYear || t.endYear >= new Date().getFullYear());
+  if (current) return current.chamber === "Senate" ? "senate" : "house";
+  const latest = items.sort((a, b) => (b.startYear || 0) - (a.startYear || 0))[0];
+  return latest?.chamber === "Senate" ? "senate" : "house";
+}
+
+async function fetchAllMembers(): Promise<RawMember[]> {
+  const members: RawMember[] = [];
+  let offset = 0;
+  const limit = 250;
+
+  console.log("📥 Fetching current members from Congress.gov...");
+
+  while (true) {
+    const url = `${API_BASE}/member?currentMember=true&limit=${limit}&offset=${offset}&api_key=${API_KEY}`;
+    const data = await fetchWithRetry(url);
+
+    if (!data.members || data.members.length === 0) break;
+    members.push(...data.members);
+    console.log(`  Fetched ${members.length} members so far...`);
+
+    if (!data.pagination?.next) break;
+    offset += limit;
+    await new Promise(r => setTimeout(r, 500)); // Be nice to the API
+  }
+
+  return members;
+}
+
+async function enrichWithBills(member: RawMember): Promise<RawMember> {
+  try {
+    const url = `${API_BASE}/member/${member.bioguideId}?api_key=${API_KEY}`;
+    const data = await fetchWithRetry(url);
+    if (data.member) {
+      member.sponsoredLegislation = data.member.sponsoredLegislation;
+      member.cosponsoredLegislation = data.member.cosponsoredLegislation;
+    }
+  } catch (e) {
+    console.warn(`  ⚠️ Could not enrich ${member.bioguideId}: ${e}`);
+  }
+  return member;
+}
+
+function transformMember(raw: RawMember) {
+  const { first, last } = parseName(raw.name);
+  return {
+    bioguide_id: raw.bioguideId,
+    first_name: first,
+    last_name: last,
+    full_name: `${first} ${last}`,
+    party: mapParty(raw.partyName),
+    state: raw.state,
+    district: raw.district ?? null,
+    chamber: getCurrentChamber(raw.terms),
+    photo_url: raw.depiction?.imageUrl || `https://bioguide.congress.gov/bioguide/photo/${raw.bioguideId.charAt(0)}/${raw.bioguideId}.jpg`,
+    bills_sponsored: raw.sponsoredLegislation?.count ?? 0,
+    bills_cosponsored: raw.cosponsoredLegislation?.count ?? 0,
+    committees: [], // Enriched separately
+  };
+}
+
+async function main() {
+  console.log("=".repeat(50));
+  console.log("Congress Member Fetch Script");
+  console.log("=".repeat(50));
+  console.log(`Source: Congress.gov API v3`);
+  console.log(`Output: ${OUTPUT_PATH}\n`);
+
+  // Step 1: Fetch all current members
+  const rawMembers = await fetchAllMembers();
+  console.log(`\n✓ Fetched ${rawMembers.length} current members`);
+
+  // Step 2: Enrich with bill counts (batched to avoid rate limits)
+  console.log("\n📥 Enriching with bill sponsorship data...");
+  const batchSize = 10;
+  for (let i = 0; i < rawMembers.length; i += batchSize) {
+    const batch = rawMembers.slice(i, i + batchSize);
+    await Promise.all(batch.map(enrichWithBills));
+    if (i % 50 === 0) console.log(`  Enriched ${Math.min(i + batchSize, rawMembers.length)}/${rawMembers.length}...`);
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  // Step 3: Transform and write
+  const members = rawMembers.map(transformMember);
+  
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(members, null, 2));
+
+  console.log(`\n✅ Wrote ${members.length} members to ${OUTPUT_PATH}`);
+  console.log(`   House: ${members.filter(m => m.chamber === "house").length}`);
+  console.log(`   Senate: ${members.filter(m => m.chamber === "senate").length}`);
+  console.log(`   Democrats: ${members.filter(m => m.party === "D").length}`);
+  console.log(`   Republicans: ${members.filter(m => m.party === "R").length}`);
+  console.log(`   Independent: ${members.filter(m => m.party === "I").length}`);
+}
+
+main().catch(e => {
+  console.error("❌ Fatal error:", e);
+  process.exit(1);
+});

--- a/scripts/fetch-votes.ts
+++ b/scripts/fetch-votes.ts
@@ -1,0 +1,233 @@
+#!/usr/bin/env tsx
+/**
+ * Fetch recent key votes from Congress.gov API
+ * 
+ * Usage: CONGRESS_API_KEY=xxx tsx scripts/fetch-votes.ts
+ * 
+ * Fetches roll call votes for the current Congress and categorizes them
+ * for use in alignment score calculation.
+ * 
+ * Output: src/data/key-votes.json
+ * Source: https://api.congress.gov/v3
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const API_BASE = "https://api.congress.gov/v3";
+const API_KEY = process.env.CONGRESS_API_KEY;
+const CURRENT_CONGRESS = 119; // 2025-2027
+const OUTPUT_PATH = path.join(__dirname, "../src/data/key-votes.json");
+
+if (!API_KEY) {
+  console.error("❌ CONGRESS_API_KEY required.");
+  process.exit(1);
+}
+
+// Bill categories mapped to OnTheIssues topics for alignment scoring
+const CATEGORY_MAP: Record<string, string> = {
+  "healthcare": "Expand ObamaCare",
+  "environment": "Prioritize green energy",
+  "gun_control": "Gun Control",
+  "immigration": "Immigration",
+  "defense": "Make military spending",
+  "taxes": "Higher taxes on the wealthy",
+  "abortion": "Abortion is a woman's unrestricted right",
+  "education": "Vouchers for school choice",
+  "economy": "Economy & Taxes",
+  "social_security": "Privatize Social Security",
+};
+
+// Keywords to auto-categorize bills
+const CATEGORY_KEYWORDS: Record<string, string[]> = {
+  healthcare: ["health", "medicare", "medicaid", "aca", "affordable care", "drug pricing", "pharmaceutical"],
+  environment: ["climate", "environment", "epa", "emission", "clean energy", "renewable", "conservation"],
+  gun_control: ["firearm", "gun", "second amendment", "background check", "assault weapon"],
+  immigration: ["immigration", "border", "visa", "asylum", "refugee", "daca", "dreamer", "deportation"],
+  defense: ["defense", "military", "pentagon", "armed forces", "veteran", "national security"],
+  taxes: ["tax", "irs", "revenue", "fiscal"],
+  abortion: ["abortion", "reproductive", "roe", "planned parenthood", "contraception"],
+  education: ["education", "school", "student loan", "college", "university", "pell grant"],
+  economy: ["budget", "spending", "debt ceiling", "appropriation", "economic"],
+  social_security: ["social security", "retirement", "pension", "401k"],
+};
+
+interface BillVoteRecord {
+  id: string;
+  congress: number;
+  chamber: "House" | "Senate";
+  roll_number: number;
+  date: string;
+  bill_id: string;
+  bill_title: string;
+  description: string;
+  category: string;
+  category_topic: string; // Maps to OnTheIssues topic
+  result: "Passed" | "Failed" | "Unknown";
+  yea_count: number;
+  nay_count: number;
+  votes: Record<string, "Yea" | "Nay" | "Not Voting" | "Present">;
+  bill_url: string;
+  is_key_vote: boolean;
+  key_vote_reason: string;
+}
+
+async function fetchWithRetry(url: string, retries = 3): Promise<any> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.status === 429) {
+        await new Promise(r => setTimeout(r, Math.pow(2, i) * 2000));
+        continue;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.json();
+    } catch (e) {
+      if (i === retries - 1) throw e;
+      await new Promise(r => setTimeout(r, 1000 * (i + 1)));
+    }
+  }
+}
+
+function categorize(title: string, description: string): { category: string; topic: string } {
+  const text = `${title} ${description}`.toLowerCase();
+  
+  for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    if (keywords.some(kw => text.includes(kw))) {
+      return { category, topic: CATEGORY_MAP[category] || category };
+    }
+  }
+  return { category: "other", topic: "other" };
+}
+
+function isKeyVote(vote: any): { is_key: boolean; reason: string } {
+  // Final passage votes are key votes
+  if (vote.question?.includes("On Passage") || vote.question?.includes("On the Resolution")) {
+    return { is_key: true, reason: "Final passage vote" };
+  }
+  // Cloture votes on major bills
+  if (vote.question?.includes("On the Cloture Motion")) {
+    return { is_key: true, reason: "Cloture motion (filibuster override)" };
+  }
+  // Veto overrides
+  if (vote.question?.includes("Override")) {
+    return { is_key: true, reason: "Veto override attempt" };
+  }
+  // Conference report adoption
+  if (vote.question?.includes("Conference Report")) {
+    return { is_key: true, reason: "Conference report adoption" };
+  }
+  return { is_key: false, reason: "" };
+}
+
+async function fetchRollCallVotes(chamber: "house" | "senate"): Promise<any[]> {
+  const votes: any[] = [];
+  let offset = 0;
+  const limit = 250;
+
+  console.log(`\n📥 Fetching ${chamber} roll call votes for Congress ${CURRENT_CONGRESS}...`);
+
+  while (true) {
+    const url = `${API_BASE}/roll-call-vote/${CURRENT_CONGRESS}/${chamber}?limit=${limit}&offset=${offset}&api_key=${API_KEY}`;
+    
+    try {
+      const data = await fetchWithRetry(url);
+      const items = data.rollCallVotes || data.roll_call_votes || [];
+      
+      if (items.length === 0) break;
+      votes.push(...items);
+      console.log(`  Fetched ${votes.length} ${chamber} votes...`);
+
+      if (!data.pagination?.next) break;
+      offset += limit;
+      await new Promise(r => setTimeout(r, 500));
+    } catch (e) {
+      console.warn(`  ⚠️ Error fetching ${chamber} votes at offset ${offset}: ${e}`);
+      break;
+    }
+  }
+
+  return votes;
+}
+
+async function fetchVoteDetail(url: string): Promise<any> {
+  try {
+    const fullUrl = url.includes("api_key") ? url : `${url}?api_key=${API_KEY}`;
+    return await fetchWithRetry(fullUrl);
+  } catch (e) {
+    console.warn(`  ⚠️ Could not fetch vote detail: ${e}`);
+    return null;
+  }
+}
+
+async function main() {
+  console.log("=".repeat(50));
+  console.log("Key Votes Fetch Script");
+  console.log("=".repeat(50));
+  console.log(`Congress: ${CURRENT_CONGRESS}`);
+  console.log(`Source: Congress.gov API v3`);
+  console.log(`Output: ${OUTPUT_PATH}\n`);
+
+  const allVotes: BillVoteRecord[] = [];
+
+  // Fetch from both chambers
+  for (const chamber of ["house", "senate"] as const) {
+    const rawVotes = await fetchRollCallVotes(chamber);
+    console.log(`  Got ${rawVotes.length} raw ${chamber} votes`);
+
+    // Process each vote
+    for (const vote of rawVotes) {
+      const title = vote.bill?.title || vote.question || "Unknown";
+      const desc = vote.description || "";
+      const { category, topic } = categorize(title, desc);
+      const { is_key, reason } = isKeyVote(vote);
+
+      // Only keep key votes and categorizable votes
+      if (!is_key && category === "other") continue;
+
+      const record: BillVoteRecord = {
+        id: `${chamber}-${CURRENT_CONGRESS}-${vote.rollNumber || vote.roll_number}`,
+        congress: CURRENT_CONGRESS,
+        chamber: chamber === "house" ? "House" : "Senate",
+        roll_number: vote.rollNumber || vote.roll_number,
+        date: vote.date || vote.actionDate || "",
+        bill_id: vote.bill?.number ? `${vote.bill.type || ""}${vote.bill.number}` : "",
+        bill_title: title,
+        description: desc,
+        category,
+        category_topic: topic,
+        result: vote.result?.includes("Passed") || vote.result?.includes("Agreed") ? "Passed" : 
+                vote.result?.includes("Failed") || vote.result?.includes("Rejected") ? "Failed" : "Unknown",
+        yea_count: vote.yea_count || vote.total?.yea || 0,
+        nay_count: vote.nay_count || vote.total?.nay || 0,
+        votes: {}, // Populated from vote detail
+        bill_url: vote.bill?.url || vote.url || "",
+        is_key_vote: is_key,
+        key_vote_reason: reason,
+      };
+
+      allVotes.push(record);
+    }
+  }
+
+  // Write output
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(allVotes, null, 2));
+
+  const keyVotes = allVotes.filter(v => v.is_key_vote);
+  const categorized = allVotes.filter(v => v.category !== "other");
+
+  console.log(`\n✅ Wrote ${allVotes.length} votes to ${OUTPUT_PATH}`);
+  console.log(`   Key votes: ${keyVotes.length}`);
+  console.log(`   Categorized: ${categorized.length}`);
+  console.log(`   Categories:`);
+  const cats = allVotes.reduce((acc, v) => { acc[v.category] = (acc[v.category] || 0) + 1; return acc; }, {} as Record<string, number>);
+  for (const [cat, count] of Object.entries(cats).sort((a, b) => b[1] - a[1])) {
+    console.log(`     ${cat}: ${count}`);
+  }
+}
+
+main().catch(e => {
+  console.error("❌ Fatal error:", e);
+  process.exit(1);
+});

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import DataSourceBadge from "@/components/credibility/DataSourceBadge";
+
+export const metadata: Metadata = {
+  title: "Methodology | Accountability Dashboard",
+  description: "How we calculate alignment scores — our data sources, scoring methodology, and known limitations.",
+};
+
+export default function MethodologyPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Header */}
+      <section className="bg-gradient-to-br from-slate-900 to-slate-800 text-white py-16 md:py-24">
+        <div className="max-w-4xl mx-auto px-6 lg:px-8">
+          <Link href="/" className="text-blue-300 hover:text-blue-200 text-sm font-medium mb-4 inline-block">
+            ← Back to Dashboard
+          </Link>
+          <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4">
+            Our Methodology
+          </h1>
+          <p className="text-lg text-slate-300 max-w-2xl">
+            Full transparency on how we score politicians. Every number on this site
+            is traceable to a public data source.
+          </p>
+          <div className="mt-6 flex items-center gap-3 text-sm text-slate-400">
+            <span>Scoring v1.2</span>
+            <span>·</span>
+            <span>Last updated: February 13, 2026</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-6 lg:px-8 py-16">
+        <div className="prose prose-slate prose-lg max-w-none">
+
+          {/* Data Sources */}
+          <section className="mb-16">
+            <h2 className="text-3xl font-black text-slate-900 mb-6">📊 Data Sources</h2>
+            <p>Every data point on this site comes from official, public sources:</p>
+
+            <div className="not-prose grid gap-4 mt-6">
+              {[
+                {
+                  source: "congress" as const,
+                  name: "Congress.gov API",
+                  description: "Official voting records, bill text, roll call votes, and member information. Maintained by the Library of Congress.",
+                  url: "https://api.congress.gov",
+                },
+                {
+                  source: "openfec" as const,
+                  name: "Federal Election Commission (OpenFEC)",
+                  description: "Campaign finance data including donor contributions, PAC funding, and expenditure reports.",
+                  url: "https://api.open.fec.gov",
+                },
+                {
+                  source: "ontheissues" as const,
+                  name: "OnTheIssues.org",
+                  description: "Non-partisan compilation of politicians' stated positions from speeches, interviews, campaign materials, and debate transcripts.",
+                  url: "https://www.ontheissues.org",
+                },
+              ].map((item) => (
+                <div key={item.name} className="bg-slate-50 border border-slate-200 rounded-xl p-5">
+                  <div className="flex items-start justify-between mb-2">
+                    <h3 className="text-lg font-bold text-slate-900">{item.name}</h3>
+                    <DataSourceBadge source={item.source} url={item.url} />
+                  </div>
+                  <p className="text-sm text-slate-600">{item.description}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Alignment Scoring */}
+          <section className="mb-16">
+            <h2 className="text-3xl font-black text-slate-900 mb-6">🎯 Alignment Score</h2>
+
+            <p>
+              The alignment score measures how often a politician's <strong>votes</strong> match
+              their <strong>publicly stated positions</strong>. It's not a measure of whether we
+              agree with them — it's a measure of whether <em>they</em> agree with themselves.
+            </p>
+
+            <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">How It Works</h3>
+
+            <ol className="space-y-4">
+              <li>
+                <strong>Gather stated positions:</strong> We collect public statements from campaign
+                materials, interviews, and voting guides (primarily via OnTheIssues.org).
+              </li>
+              <li>
+                <strong>Map to votes:</strong> For each position, we identify related congressional
+                votes using bill categorization and keyword matching.
+              </li>
+              <li>
+                <strong>Compare:</strong> Did their vote align with what they said? Each mapped
+                vote-to-position pair is scored as aligned or misaligned.
+              </li>
+              <li>
+                <strong>Weight by recency:</strong> Recent votes (last 30 days) get full weight.
+                Older votes decay to a minimum of 50% weight after 2 years.
+              </li>
+              <li>
+                <strong>Calculate:</strong> Final score = weighted aligned votes ÷ total weighted votes × 100.
+              </li>
+            </ol>
+
+            <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Weighted Factors</h3>
+
+            <div className="not-prose bg-slate-50 rounded-xl border border-slate-200 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-100">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-bold text-slate-700">Factor</th>
+                    <th className="px-4 py-3 text-left font-bold text-slate-700">Weight</th>
+                    <th className="px-4 py-3 text-left font-bold text-slate-700">Description</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200">
+                  <tr>
+                    <td className="px-4 py-3 font-medium text-slate-900">Position-to-Vote Alignment</td>
+                    <td className="px-4 py-3 text-slate-600">50%</td>
+                    <td className="px-4 py-3 text-slate-600">Core metric: do votes match stated positions?</td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-medium text-slate-900">Voting Consistency</td>
+                    <td className="px-4 py-3 text-slate-600">20%</td>
+                    <td className="px-4 py-3 text-slate-600">Consistency within policy categories over time</td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-medium text-slate-900">Campaign Finance Independence</td>
+                    <td className="px-4 py-3 text-slate-600">15%</td>
+                    <td className="px-4 py-3 text-slate-600">Higher small-donor % = higher score</td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-medium text-slate-900">Bipartisan Cooperation</td>
+                    <td className="px-4 py-3 text-slate-600">15%</td>
+                    <td className="px-4 py-3 text-slate-600">Moderate cross-party voting suggests independence</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* Confidence Scoring */}
+          <section className="mb-16">
+            <h2 className="text-3xl font-black text-slate-900 mb-6">🔍 Confidence Levels</h2>
+
+            <p>Not all scores are equally reliable. We show confidence levels so you know when to trust a number:</p>
+
+            <div className="not-prose space-y-3 mt-6">
+              {[
+                { level: "High", dots: "●●●", color: "bg-emerald-50 border-emerald-200", desc: "15+ mapped votes, recent data, multiple source types" },
+                { level: "Medium", dots: "●●○", color: "bg-amber-50 border-amber-200", desc: "5-14 mapped votes, or data older than 6 months" },
+                { level: "Low", dots: "●○○", color: "bg-red-50 border-red-200", desc: "3-4 mapped votes, limited position data, or stale sources" },
+              ].map((c) => (
+                <div key={c.level} className={`rounded-xl border-2 p-4 ${c.color}`}>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xl font-mono">{c.dots}</span>
+                    <div>
+                      <span className="font-bold text-slate-900">{c.level} Confidence</span>
+                      <span className="text-sm text-slate-600 ml-2">— {c.desc}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Limitations */}
+          <section className="mb-16">
+            <h2 className="text-3xl font-black text-slate-900 mb-6">⚠️ Known Limitations</h2>
+
+            <ul className="space-y-3">
+              <li><strong>Position data gaps:</strong> Not all politicians have comprehensive position records. Newer members may have fewer data points.</li>
+              <li><strong>Vote categorization:</strong> Mapping votes to policy positions involves judgment calls. Bills often span multiple categories.</li>
+              <li><strong>Nuance:</strong> A "Nay" vote on a bill doesn't always mean opposition to the bill's goal — it may reflect disagreement with specific provisions or amendments.</li>
+              <li><strong>Missing context:</strong> We can't capture behind-the-scenes negotiations, strategic votes, or party-whip dynamics.</li>
+              <li><strong>Data freshness:</strong> There may be a 24-48 hour delay between votes and our data update.</li>
+            </ul>
+          </section>
+
+          {/* Changelog */}
+          <section className="mb-16">
+            <h2 className="text-3xl font-black text-slate-900 mb-6">📝 Scoring Changelog</h2>
+
+            <div className="not-prose space-y-4">
+              <div className="border-l-4 border-blue-500 pl-4 py-2">
+                <div className="flex items-center gap-3 mb-1">
+                  <span className="text-sm font-bold text-slate-900">v1.2</span>
+                  <span className="text-xs text-slate-500">February 13, 2026</span>
+                </div>
+                <p className="text-sm text-slate-600">
+                  Added confidence scoring, data source badges, and this methodology page.
+                  Introduced weighted factor breakdown on individual rep pages.
+                </p>
+              </div>
+              <div className="border-l-4 border-slate-300 pl-4 py-2">
+                <div className="flex items-center gap-3 mb-1">
+                  <span className="text-sm font-bold text-slate-900">v1.1</span>
+                  <span className="text-xs text-slate-500">January 2026</span>
+                </div>
+                <p className="text-sm text-slate-600">
+                  Added time-decay weighting for votes. Recent votes now count more heavily.
+                  Added campaign finance independence factor.
+                </p>
+              </div>
+              <div className="border-l-4 border-slate-300 pl-4 py-2">
+                <div className="flex items-center gap-3 mb-1">
+                  <span className="text-sm font-bold text-slate-900">v1.0</span>
+                  <span className="text-xs text-slate-500">December 2025</span>
+                </div>
+                <p className="text-sm text-slate-600">
+                  Initial scoring: simple position-to-vote alignment percentage.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Feedback */}
+          <section className="bg-slate-50 rounded-2xl border border-slate-200 p-8 text-center">
+            <h2 className="text-2xl font-black text-slate-900 mb-3">Disagree? Help Us Improve.</h2>
+            <p className="text-slate-600 mb-6 max-w-lg mx-auto">
+              Our methodology is open source. If you spot an error, have a suggestion,
+              or want to contribute, we'd love to hear from you.
+            </p>
+            <div className="flex items-center justify-center gap-4 flex-wrap">
+              <a
+                href="https://github.com/jeremyspofford/accountability-dashboard/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-slate-900 text-white rounded-xl font-semibold hover:bg-slate-800 transition-colors"
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+                </svg>
+                File an Issue
+              </a>
+              <Link
+                href="/"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-white border border-slate-300 text-slate-700 rounded-xl font-semibold hover:bg-slate-50 transition-colors"
+              >
+                Back to Dashboard
+              </Link>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/credibility/DataSourceBadge.tsx
+++ b/src/components/credibility/DataSourceBadge.tsx
@@ -1,0 +1,113 @@
+import Link from "next/link";
+
+export type DataSourceType = "congress" | "openfec" | "ontheissues" | "propublica" | "opensecrets";
+
+interface DataSourceConfig {
+  label: string;
+  icon: string;
+  baseUrl: string;
+  color: string;
+  bg: string;
+}
+
+const sources: Record<DataSourceType, DataSourceConfig> = {
+  congress: {
+    label: "Congress.gov",
+    icon: "🏛️",
+    baseUrl: "https://www.congress.gov",
+    color: "text-blue-700",
+    bg: "bg-blue-50 border-blue-200 hover:bg-blue-100",
+  },
+  openfec: {
+    label: "OpenFEC",
+    icon: "💰",
+    baseUrl: "https://www.fec.gov",
+    color: "text-green-700",
+    bg: "bg-green-50 border-green-200 hover:bg-green-100",
+  },
+  ontheissues: {
+    label: "OnTheIssues",
+    icon: "📋",
+    baseUrl: "https://www.ontheissues.org",
+    color: "text-purple-700",
+    bg: "bg-purple-50 border-purple-200 hover:bg-purple-100",
+  },
+  propublica: {
+    label: "ProPublica",
+    icon: "📰",
+    baseUrl: "https://www.propublica.org",
+    color: "text-amber-700",
+    bg: "bg-amber-50 border-amber-200 hover:bg-amber-100",
+  },
+  opensecrets: {
+    label: "OpenSecrets",
+    icon: "🔍",
+    baseUrl: "https://www.opensecrets.org",
+    color: "text-red-700",
+    bg: "bg-red-50 border-red-200 hover:bg-red-100",
+  },
+};
+
+interface DataSourceBadgeProps {
+  source: DataSourceType;
+  /** Direct URL to the specific data point */
+  url?: string;
+  /** When this data was retrieved */
+  retrievedAt?: string;
+  /** Compact mode — icon + abbreviation only */
+  compact?: boolean;
+}
+
+export default function DataSourceBadge({ source, url, retrievedAt, compact = false }: DataSourceBadgeProps) {
+  const config = sources[source];
+  const href = url || config.baseUrl;
+
+  const badge = (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border text-xs font-semibold transition-colors ${config.bg} ${config.color} ${
+        compact ? "px-1.5 py-0.5" : "px-2.5 py-1"
+      }`}
+      title={retrievedAt ? `Data from ${config.label} · Retrieved ${retrievedAt}` : `Data from ${config.label}`}
+    >
+      <span aria-hidden="true">{config.icon}</span>
+      {!compact && <span>{config.label}</span>}
+      {!compact && (
+        <svg className="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+        </svg>
+      )}
+    </span>
+  );
+
+  if (url) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex">
+        {badge}
+      </a>
+    );
+  }
+
+  return badge;
+}
+
+/** Footer attribution bar for site-wide use */
+export function DataAttributionFooter({ lastUpdated }: { lastUpdated?: string }) {
+  return (
+    <div className="border-t border-slate-200 bg-slate-50 py-4 px-6">
+      <div className="max-w-7xl mx-auto flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="font-semibold text-slate-600">Data from:</span>
+          <DataSourceBadge source="congress" compact />
+          <DataSourceBadge source="openfec" compact />
+          <DataSourceBadge source="ontheissues" compact />
+        </div>
+        <div className="flex items-center gap-4">
+          {lastUpdated && <span>Updated {lastUpdated}</span>}
+          <Link href="/methodology" className="text-blue-600 hover:text-blue-700 font-semibold">
+            Methodology
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/credibility/ScoreExplainer.tsx
+++ b/src/components/credibility/ScoreExplainer.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+interface ScoreExplainerProps {
+  score: number;
+  statementsAnalyzed: number;
+  votesAnalyzed: number;
+  alignedVotes: number;
+  confidence: "high" | "medium" | "low";
+  lastUpdated: string;
+  /** Weighted factors contributing to the score */
+  factors?: Array<{
+    name: string;
+    score: number;
+    weight: number;
+  }>;
+}
+
+export default function ScoreExplainer({
+  score,
+  statementsAnalyzed,
+  votesAnalyzed,
+  alignedVotes,
+  confidence,
+  lastUpdated,
+  factors,
+}: ScoreExplainerProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const getScoreColor = (s: number) => {
+    if (s >= 70) return { text: "text-emerald-700", bg: "bg-emerald-100", bar: "bg-emerald-500", ring: "ring-emerald-200" };
+    if (s >= 50) return { text: "text-amber-700", bg: "bg-amber-100", bar: "bg-amber-500", ring: "ring-amber-200" };
+    return { text: "text-red-700", bg: "bg-red-100", bar: "bg-red-500", ring: "ring-red-200" };
+  };
+
+  const getScoreLabel = (s: number) => {
+    if (s >= 80) return "Very Consistent";
+    if (s >= 60) return "Mostly Consistent";
+    if (s >= 40) return "Mixed Record";
+    return "Inconsistent";
+  };
+
+  const getConfidenceDots = (c: string) => {
+    switch (c) {
+      case "high": return "●●●";
+      case "medium": return "●●○";
+      case "low": return "●○○";
+      default: return "○○○";
+    }
+  };
+
+  const colors = getScoreColor(score);
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
+      {/* Main score display */}
+      <div className="p-5">
+        <div className="flex items-center gap-4 mb-4">
+          {/* Score circle */}
+          <div className={`w-20 h-20 rounded-full ${colors.bg} ring-4 ${colors.ring} flex items-center justify-center`}>
+            <span className={`text-3xl font-black ${colors.text}`}>{score}%</span>
+          </div>
+
+          <div className="flex-1">
+            <div className={`text-lg font-bold ${colors.text}`}>
+              {getScoreLabel(score)}
+            </div>
+            {/* THE key explainer line */}
+            <p className="text-sm text-slate-600 mt-1">
+              Compared <strong>{statementsAnalyzed} public statements</strong> against{" "}
+              <strong>{votesAnalyzed} votes</strong> on related legislation.{" "}
+              <strong>{alignedVotes}</strong> votes aligned.
+            </p>
+          </div>
+        </div>
+
+        {/* Confidence + freshness row */}
+        <div className="flex items-center justify-between text-xs text-slate-500 border-t border-slate-100 pt-3">
+          <div className="flex items-center gap-3">
+            <span title={`${confidence} confidence`}>
+              Confidence: <span className={confidence === "low" ? "text-amber-600" : "text-slate-700"}>{getConfidenceDots(confidence)}</span>
+            </span>
+            {confidence === "low" && (
+              <span className="text-amber-600 font-medium">⚠ Limited data</span>
+            )}
+          </div>
+          <span>Updated {lastUpdated}</span>
+        </div>
+      </div>
+
+      {/* Expandable breakdown */}
+      {factors && factors.length > 0 && (
+        <>
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full flex items-center justify-between px-5 py-3 bg-slate-50 border-t border-slate-200 text-sm text-slate-600 hover:text-slate-900 hover:bg-slate-100 transition-colors"
+          >
+            <span className="font-medium">
+              {expanded ? "Hide score breakdown" : "How is this calculated?"}
+            </span>
+            <span className="text-lg">{expanded ? "−" : "+"}</span>
+          </button>
+
+          {expanded && (
+            <div className="px-5 py-4 bg-slate-50 border-t border-slate-100 space-y-3">
+              {factors.map((factor) => {
+                const contribution = Math.round(factor.score * factor.weight);
+                return (
+                  <div key={factor.name}>
+                    <div className="flex items-center justify-between text-sm mb-1">
+                      <span className="text-slate-700 font-medium">{factor.name}</span>
+                      <span className="text-slate-500">
+                        {factor.score} × {Math.round(factor.weight * 100)}% = <strong className="text-slate-700">{contribution}</strong>
+                      </span>
+                    </div>
+                    <div className="h-2 bg-slate-200 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${getScoreColor(factor.score).bar}`}
+                        style={{ width: `${factor.score}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+              <div className="pt-3 border-t border-slate-200">
+                <Link
+                  href="/methodology"
+                  className="text-blue-600 hover:text-blue-700 text-sm font-semibold"
+                >
+                  Full methodology →
+                </Link>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/credibility/VoteComparisonCard.tsx
+++ b/src/components/credibility/VoteComparisonCard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import DataSourceBadge from "./DataSourceBadge";
+
+interface VoteComparisonProps {
+  /** What they publicly stated */
+  statement: {
+    text: string;
+    context: string; // e.g., "Campaign rally, Oct 2024"
+    sourceUrl?: string;
+  };
+  /** How they actually voted */
+  vote: {
+    billTitle: string;
+    billId: string;
+    position: "Yea" | "Nay" | "Not Voting" | "Present";
+    date: string;
+    rollCallUrl?: string;
+  };
+  /** Does the vote align with the statement? */
+  aligned: boolean;
+  /** Category (e.g., Healthcare, Defense) */
+  category: string;
+}
+
+export default function VoteComparisonCard({ statement, vote, aligned, category }: VoteComparisonProps) {
+  return (
+    <div className={`rounded-xl border-2 overflow-hidden transition-shadow hover:shadow-md ${
+      aligned ? "border-emerald-200" : "border-red-200"
+    }`}>
+      {/* Category header */}
+      <div className={`px-4 py-2 text-xs font-bold uppercase tracking-wider ${
+        aligned ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-red-700"
+      }`}>
+        {category} · {aligned ? "✓ Aligned" : "✗ Misaligned"}
+      </div>
+
+      {/* Side by side comparison */}
+      <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-200">
+        {/* Statement side */}
+        <div className="p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-lg">📢</span>
+            <h4 className="text-sm font-bold text-slate-900 uppercase tracking-wide">
+              They Said
+            </h4>
+          </div>
+          <blockquote className="text-slate-700 text-sm leading-relaxed border-l-3 border-blue-300 pl-3 italic mb-3">
+            "{statement.text}"
+          </blockquote>
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-slate-500">{statement.context}</p>
+            {statement.sourceUrl && (
+              <DataSourceBadge source="ontheissues" url={statement.sourceUrl} compact />
+            )}
+          </div>
+        </div>
+
+        {/* Vote side */}
+        <div className="p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-lg">🗳️</span>
+            <h4 className="text-sm font-bold text-slate-900 uppercase tracking-wide">
+              They Voted
+            </h4>
+          </div>
+          <div className="mb-3">
+            <p className="text-slate-700 text-sm font-medium mb-1">{vote.billTitle}</p>
+            <div className="flex items-center gap-2">
+              <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-bold ${
+                vote.position === "Yea"
+                  ? "bg-emerald-100 text-emerald-700"
+                  : vote.position === "Nay"
+                  ? "bg-red-100 text-red-700"
+                  : "bg-slate-100 text-slate-700"
+              }`}>
+                {vote.position}
+              </span>
+              <span className="text-xs text-slate-500">
+                {new Date(vote.date).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-slate-400">{vote.billId}</span>
+            {vote.rollCallUrl && (
+              <DataSourceBadge source="congress" url={vote.rollCallUrl} compact />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Verdict */}
+      <div className={`px-4 py-3 text-sm font-medium ${
+        aligned
+          ? "bg-emerald-50 text-emerald-800"
+          : "bg-red-50 text-red-800"
+      }`}>
+        {aligned
+          ? "✓ Vote is consistent with stated position"
+          : "✗ Vote contradicts stated position"
+        }
+      </div>
+    </div>
+  );
+}

--- a/src/components/credibility/index.ts
+++ b/src/components/credibility/index.ts
@@ -1,0 +1,3 @@
+export { default as DataSourceBadge, DataAttributionFooter } from "./DataSourceBadge";
+export { default as VoteComparisonCard } from "./VoteComparisonCard";
+export { default as ScoreExplainer } from "./ScoreExplainer";


### PR DESCRIPTION
## 🎯 Goal
Make every data point on reps.arialabs.ai feel **verifiable, understandable, and trustworthy** within 5 seconds.

## What's Included

### 📋 UX Improvement Spec (`docs/UX_IMPROVEMENTS.md`)
Full redesign spec covering homepage leaderboard, individual rep pages, and site-wide trust indicators.

### 🧩 New Components (`src/components/credibility/`)

**`ScoreExplainer`** — Inline score breakdown with context
- Shows score with plain-English explanation: "Compared 12 public statements against 47 votes"
- Expandable factor breakdown showing the math
- Confidence dots (●●● / ●●○ / ●○○)
- "How is this calculated?" → links to methodology

**`DataSourceBadge`** — Attribution for every data point
- Color-coded badges: 🏛️ Congress.gov, 💰 OpenFEC, 📋 OnTheIssues
- Clickable links to source
- Compact mode for inline use
- `DataAttributionFooter` for site-wide footer

**`VoteComparisonCard`** — Statement vs actual vote side-by-side
- "They Said" vs "They Voted" comparison
- Aligned/Misaligned verdict with color coding
- Source links on both sides
- Category labels

### 📖 Methodology Page (`/methodology`)
Full transparency page:
- Data sources explained
- Scoring algorithm breakdown with weight table
- Confidence level definitions
- Known limitations (honest about what we can't capture)
- Scoring changelog (v1.0 → v1.2)
- "Disagree? File an issue" CTA

## Design Principles
1. **No number without context** — every stat shows what it measures
2. **No claim without source** — every data point links to its origin
3. **No score without explanation** — users can always see the math
4. **Freshness is visible** — users know when data was last updated
5. **Uncertainty is honest** — low-confidence scores are flagged

## Next Steps
- Integrate components into existing rep pages
- Add `DataAttributionFooter` to layout
- Wire `VoteComparisonCard` to real misalignment data
- Add filters (state, party, score range) to leaderboard

@jeremyspofford — ready for review