### PR TITLE
feat(executive): 'Who Does This Official Serve?' verdict banner — closes #121

### DIFF
--- a/src/app/executive/cabinet/[role]/page.tsx
+++ b/src/app/executive/cabinet/[role]/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/revolving-door";
 import { generatePersonSchema, generateBreadcrumbSchema, structuredDataScript } from "@/lib/schema";
 import { Container } from "@/components/ui";
+import { VerdictBanner } from "@/components/VerdictBanner";
 
 export async function generateMetadata({ params }: CabinetMemberPageProps): Promise<Metadata> {
   const { role } = await params;
@@ -144,6 +145,15 @@ export default async function CabinetMemberPage({ params }: CabinetMemberPagePro
         </Container>
       </section>
 
+      {/* Verdict Banner */}
+      {rdEntry && (
+        <section className="pt-8 pb-0">
+          <Container>
+            <VerdictBanner entry={rdEntry} expandTargetId="revolving-door" />
+          </Container>
+        </section>
+      )}
+
       {/* Details Section */}
       <section className="py-12">
         <Container>
@@ -215,7 +225,7 @@ export default async function CabinetMemberPage({ params }: CabinetMemberPagePro
             const rdIcon = getRevolvingDoorIcon(rdEntry.type);
             const isHighRisk = rdEntry.type === "industry_insider" || rdEntry.type === "ideological_conflict";
             return (
-              <div className={`rounded-2xl border-2 p-8 mb-8 ${isHighRisk ? "bg-orange-50 border-orange-300" : "bg-slate-50 border-slate-200"}`}>
+              <div id="revolving-door" className={`rounded-2xl border-2 p-8 mb-8 ${isHighRisk ? "bg-orange-50 border-orange-300" : "bg-slate-50 border-slate-200"}`}>
                 <h2 className={`text-2xl font-black mb-3 flex items-center gap-2 ${isHighRisk ? "text-orange-900" : "text-slate-700"}`}>
                   <span>{rdIcon}</span>
                   Revolving Door Analysis

--- a/src/components/VerdictBanner.test.tsx
+++ b/src/components/VerdictBanner.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { VerdictBanner } from "./VerdictBanner";
+import type { RevolvingDoorEntry } from "@/lib/revolving-door";
+
+const industryInsider: RevolvingDoorEntry = {
+  type: "industry_insider",
+  prior_industry: "Liberty Energy (Fossil Fuel / Fracking CEO)",
+  summary: "CEO of Liberty Energy, a fracking services company. Now heads the Department of Energy.",
+  severity: "critical",
+};
+
+const ideologicalConflict: RevolvingDoorEntry = {
+  type: "ideological_conflict",
+  prior_industry: "Children's Health Defense (Anti-Vaccine Advocacy)",
+  summary: "Founded and led an anti-vaccine advocacy organization. Now heads HHS.",
+  severity: "critical",
+};
+
+const lobbyingDoor: RevolvingDoorEntry = {
+  type: "lobbying_door",
+  prior_industry: "Fox News / Media",
+  summary: "Fox News host with no transportation industry experience.",
+  severity: "high",
+};
+
+const publicService: RevolvingDoorEntry = {
+  type: "public_service",
+  prior_industry: "U.S. Senate / Florida Legislature",
+  summary: "Career politician from U.S. Senate — no direct industry conflict.",
+  severity: "low",
+};
+
+describe("VerdictBanner", () => {
+  it("renders the verdict headline", () => {
+    render(<VerdictBanner entry={industryInsider} />);
+    expect(screen.getByText("Who Does This Official Serve?")).toBeInTheDocument();
+  });
+
+  it("shows prior industry", () => {
+    render(<VerdictBanner entry={industryInsider} />);
+    expect(screen.getByText(industryInsider.prior_industry)).toBeInTheDocument();
+  });
+
+  it("shows summary text", () => {
+    render(<VerdictBanner entry={industryInsider} />);
+    expect(screen.getByText(industryInsider.summary)).toBeInTheDocument();
+  });
+
+  it("applies red background for industry_insider", () => {
+    const { container } = render(<VerdictBanner entry={industryInsider} />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toMatch(/bg-red/);
+  });
+
+  it("applies red background for ideological_conflict", () => {
+    const { container } = render(<VerdictBanner entry={ideologicalConflict} />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toMatch(/bg-red/);
+  });
+
+  it("applies amber background for lobbying_door", () => {
+    const { container } = render(<VerdictBanner entry={lobbyingDoor} />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toMatch(/bg-amber/);
+  });
+
+  it("applies green background for public_service", () => {
+    const { container } = render(<VerdictBanner entry={publicService} />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toMatch(/bg-green/);
+  });
+
+  it("shows verdict label for each type", () => {
+    const { rerender } = render(<VerdictBanner entry={industryInsider} />);
+    expect(screen.getByText("Industry Insider")).toBeInTheDocument();
+
+    rerender(<VerdictBanner entry={ideologicalConflict} />);
+    expect(screen.getByText("Mission Conflict")).toBeInTheDocument();
+
+    rerender(<VerdictBanner entry={lobbyingDoor} />);
+    expect(screen.getByText("Lobbyist / Media")).toBeInTheDocument();
+
+    rerender(<VerdictBanner entry={publicService} />);
+    expect(screen.getByText("Public Service")).toBeInTheDocument();
+  });
+
+  it("expands to show detail section on click", () => {
+    render(<VerdictBanner entry={industryInsider} expandTargetId="revolving-door" />);
+    const button = screen.getByRole("button", { name: /see full analysis/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("does not render expand button when no expandTargetId", () => {
+    render(<VerdictBanner entry={industryInsider} />);
+    expect(screen.queryByRole("button", { name: /see full analysis/i })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when entry is null", () => {
+    const { container } = render(<VerdictBanner entry={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/VerdictBanner.tsx
+++ b/src/components/VerdictBanner.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { getRevolvingDoorLabel } from "@/lib/revolving-door";
+import type { RevolvingDoorEntry, RevolvingDoorType } from "@/lib/revolving-door";
+
+const bgColors: Record<RevolvingDoorType, string> = {
+  industry_insider: "bg-red-50 border-red-300 text-red-900",
+  ideological_conflict: "bg-red-50 border-red-300 text-red-900",
+  lobbying_door: "bg-amber-50 border-amber-300 text-amber-900",
+  public_service: "bg-green-50 border-green-300 text-green-900",
+};
+
+const summaryColors: Record<RevolvingDoorType, string> = {
+  industry_insider: "text-red-800",
+  ideological_conflict: "text-red-800",
+  lobbying_door: "text-amber-800",
+  public_service: "text-green-800",
+};
+
+interface VerdictBannerProps {
+  entry: RevolvingDoorEntry | null;
+  expandTargetId?: string;
+}
+
+export function VerdictBanner({ entry, expandTargetId }: VerdictBannerProps) {
+  if (!entry) return null;
+
+  const colors = bgColors[entry.type];
+  const summaryColor = summaryColors[entry.type];
+  const label = getRevolvingDoorLabel(entry.type);
+
+  const scrollToTarget = () => {
+    if (!expandTargetId) return;
+    const el = document.getElementById(expandTargetId);
+    el?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <div className={`rounded-2xl border-2 p-6 md:p-8 ${colors}`}>
+      <h2 className="text-xl md:text-2xl font-black mb-1">
+        Who Does This Official Serve?
+      </h2>
+      <span className="inline-block text-sm font-bold uppercase tracking-wider mb-3 opacity-80">
+        {label}
+      </span>
+      <div className="mb-2">
+        <span className="text-sm font-semibold uppercase tracking-wider opacity-70">Prior Industry: </span>
+        <span className="font-semibold">{entry.prior_industry}</span>
+      </div>
+      <p className={`text-base leading-relaxed ${summaryColor}`}>
+        {entry.summary}
+      </p>
+      {expandTargetId && (
+        <button
+          onClick={scrollToTarget}
+          className="mt-4 text-sm font-semibold underline underline-offset-2 hover:opacity-80"
+        >
+          See full analysis
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a prominent verdict banner to all cabinet member pages showing whether the official primarily serves industry or public interests.

## Changes
- `VerdictBanner.tsx` — Color-coded verdict card (red for industry insider/ideological conflict, amber for revolving door, green for public service)
- `VerdictBanner.test.tsx` — 11 tests covering all variants, content rendering, expand behavior, and null handling
- Cabinet `[role]/page.tsx` — Banner injected above bio section as the first thing visitors see

## Tests
- 738/738 tests pass (full suite)
- Build succeeds, no TypeScript errors

Closes #121