### PR TITLE
feat(#128): ZIP code → Find Your Reps feature

### DIFF
--- a/functions/api/find-reps.js
+++ b/functions/api/find-reps.js
@@ -1,0 +1,171 @@
+/**
+ * Cloudflare Pages Function: GET /api/find-reps?zip=XXXXX
+ *
+ * Resolves a 5-digit US ZIP code to:
+ *  - 1 House Representative (via ZIP → lat/lng → congressional district)
+ *  - 2 Senators (via state code)
+ *
+ * Returns:
+ *   { reps: RawRep[], state: string, district: string }
+ *   or { fallback: true } on any error
+ *
+ * Env vars required:
+ *   CONGRESS_API_KEY  — Congress.gov v3 API key
+ *
+ * Issue #128
+ */
+
+const ZIP_RE = /^\d{5}$/;
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'public, max-age=86400', // cache 24h — districts rarely change
+};
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: CORS_HEADERS });
+}
+
+function mapParty(partyName) {
+  if (!partyName) return 'I';
+  const p = partyName.toLowerCase();
+  if (p.includes('democrat')) return 'D';
+  if (p.includes('republican')) return 'R';
+  return 'I';
+}
+
+/**
+ * Determine if a Congress.gov member is currently serving in the given chamber.
+ * A member is current if their latest term has no endYear (still serving).
+ */
+function isCurrentChamber(member, chamber) {
+  const terms = member.terms?.item ?? [];
+  if (!terms.length) return false;
+  const latest = terms[terms.length - 1];
+  return latest.chamber === chamber && !latest.endYear;
+}
+
+/**
+ * Shape a Congress.gov member response object into our RawRep format.
+ */
+function shapeRep(member, stateCode, chamber, district = null) {
+  return {
+    bioguide_id: member.bioguideId,
+    name: member.name,
+    party: mapParty(member.partyName),
+    state: stateCode,
+    chamber,
+    district,
+    photo_url: member.depiction?.imageUrl ?? null,
+  };
+}
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const url = new URL(request.url);
+  const zip = (url.searchParams.get('zip') ?? '').trim();
+
+  // ── Validate ZIP ──────────────────────────────────────────────────────────
+  if (!ZIP_RE.test(zip)) {
+    return json({ error: 'Invalid ZIP code. Provide exactly 5 digits.' }, 400);
+  }
+
+  const apiKey = env.CONGRESS_API_KEY;
+  if (!apiKey) {
+    console.error('CONGRESS_API_KEY not set');
+    return json({ fallback: true });
+  }
+
+  try {
+    // ── Step 1: ZIP → lat/lng + state (zippopotam.us — free, no auth) ────────
+    const zippRes = await fetch(`https://api.zippopotam.us/us/${zip}`, {
+      headers: { 'User-Agent': 'accountability-dashboard/1.0' },
+    });
+    if (!zippRes.ok) {
+      console.warn(`zippopotam returned ${zippRes.status} for ZIP ${zip}`);
+      return json({ fallback: true });
+    }
+    const zippData = await zippRes.json();
+    const place = zippData?.places?.[0];
+    if (!place) {
+      return json({ fallback: true });
+    }
+
+    const lat = place.latitude;
+    const lon = place.longitude;
+    const stateCode = place['state abbreviation']; // e.g. "NY"
+
+    // ── Step 2: lat/lng → Congressional District (Census Geocoder — free) ────
+    let districtNum = null;
+    try {
+      const censusUrl =
+        `https://geocoding.geo.census.gov/geocoder/geographies/coordinates` +
+        `?x=${encodeURIComponent(lon)}&y=${encodeURIComponent(lat)}` +
+        `&benchmark=Public_AR_Current&vintage=Current_Current&layers=54&format=json`;
+      const censusRes = await fetch(censusUrl, { signal: AbortSignal.timeout(5000) });
+      if (censusRes.ok) {
+        const censusData = await censusRes.json();
+        const geos = censusData?.result?.geographies ?? {};
+        // Layer 54 = Congressional Districts (current congress); key varies by congress session
+        const districtLayer = Object.values(geos).flat();
+        if (districtLayer.length > 0) {
+          districtNum = districtLayer[0].BASENAME; // e.g. "12"
+        }
+      }
+    } catch (censusErr) {
+      console.warn('Census geocoder failed:', censusErr.message);
+      // Non-fatal — we can still return senators even without House member
+    }
+
+    // ── Step 3: Fetch House member (state + district) ─────────────────────────
+    const reps = [];
+
+    if (districtNum) {
+      try {
+        const houseUrl =
+          `https://api.congress.gov/v3/member/${stateCode}/${districtNum}` +
+          `?currentMember=true&limit=10&api_key=${apiKey}`;
+        const houseRes = await fetch(houseUrl, { signal: AbortSignal.timeout(8000) });
+        if (houseRes.ok) {
+          const houseData = await houseRes.json();
+          const houseMember = (houseData.members ?? []).find(
+            (m) => isCurrentChamber(m, 'House of Representatives')
+          );
+          if (houseMember) {
+            reps.push(shapeRep(houseMember, stateCode, 'house', districtNum));
+          }
+        }
+      } catch (houseErr) {
+        console.warn('House lookup failed:', houseErr.message);
+      }
+    }
+
+    // ── Step 4: Fetch Senators (state) ────────────────────────────────────────
+    try {
+      const senateUrl =
+        `https://api.congress.gov/v3/member/${stateCode}` +
+        `?currentMember=true&limit=20&api_key=${apiKey}`;
+      const senateRes = await fetch(senateUrl, { signal: AbortSignal.timeout(8000) });
+      if (senateRes.ok) {
+        const senateData = await senateRes.json();
+        const senators = (senateData.members ?? [])
+          .filter((m) => isCurrentChamber(m, 'Senate'))
+          .slice(0, 2);
+        for (const sen of senators) {
+          reps.push(shapeRep(sen, stateCode, 'senate', null));
+        }
+      }
+    } catch (senErr) {
+      console.warn('Senate lookup failed:', senErr.message);
+    }
+
+    if (reps.length === 0) {
+      return json({ fallback: true });
+    }
+
+    return json({ reps, state: stateCode, district: districtNum });
+  } catch (err) {
+    console.error('find-reps unhandled error:', err);
+    return json({ fallback: true });
+  }
+}

--- a/src/components/RepSearch.tsx
+++ b/src/components/RepSearch.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { isZipCode, fetchRepsByZip, enrichRepsWithVerdicts, type EnrichedRep } from '@/lib/find-reps';
+import { RepVerdictBadge } from '@/components/RepVerdictBadge';
+import financeData from '@/data/finance.json';
 
 // Notable reps for autocomplete suggestions — party + photo
 const NOTABLE_REPS = [
@@ -32,11 +35,45 @@ function SearchIcon({ size = 'default' }: { size?: 'default' | 'large' }) {
   );
 }
 
+function LocationPinIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+    </svg>
+  );
+}
+
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center py-6">
+      <div className="animate-spin rounded-full h-6 w-6 border-2 border-teal-600 border-t-transparent" />
+      <span className="ml-2 text-sm text-slate-500" style={{ fontFamily: "'Source Sans 3', sans-serif" }}>
+        Looking up your reps…
+      </span>
+    </div>
+  );
+}
+
 interface RepSearchProps {
   placeholder?: string;
   className?: string;
   size?: 'default' | 'large';
 }
+
+// Cast the imported finance JSON to a workable type
+const financeMap = financeData as Record<string, { pac_percentage: number }>;
 
 export default function RepSearch({
   placeholder = "Search by name, state, or ZIP code",
@@ -47,45 +84,108 @@ export default function RepSearch({
   const [suggestions, setSuggestions] = useState<typeof NOTABLE_REPS>([]);
   const [isFocused, setIsFocused] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+
+  // ZIP lookup state
+  const [zipLoading, setZipLoading] = useState(false);
+  const [zipReps, setZipReps] = useState<EnrichedRep[] | null>(null);
+  const [zipState, setZipState] = useState<string | null>(null);
+  const [zipError, setZipError] = useState(false);
+  const [lastSearchedZip, setLastSearchedZip] = useState<string | null>(null);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const zipTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const router = useRouter();
+
+  // Dismiss ZIP panel
+  const clearZipResults = useCallback(() => {
+    setZipReps(null);
+    setZipState(null);
+    setZipError(false);
+    setLastSearchedZip(null);
+  }, []);
 
   useEffect(() => {
     if (query.length >= 2) {
-      // Simulate brief "scanning" while filtering
       setIsSearching(true);
       if (searchTimer.current) clearTimeout(searchTimer.current);
       searchTimer.current = setTimeout(() => {
-        const q = query.toLowerCase();
-        setSuggestions(
-          NOTABLE_REPS.filter(r =>
-            r.name.toLowerCase().includes(q) ||
-            r.role.toLowerCase().includes(q) ||
-            r.state.toLowerCase().includes(q)
-          ).slice(0, 5)
-        );
-        setIsSearching(false);
+        if (isZipCode(query)) {
+          // ZIP mode — clear name suggestions
+          setSuggestions([]);
+          setIsSearching(false);
+        } else {
+          const q = query.toLowerCase();
+          setSuggestions(
+            NOTABLE_REPS.filter(r =>
+              r.name.toLowerCase().includes(q) ||
+              r.role.toLowerCase().includes(q) ||
+              r.state.toLowerCase().includes(q)
+            ).slice(0, 5)
+          );
+          setIsSearching(false);
+          // Clear ZIP results if user switched to name search
+          if (zipReps !== null) clearZipResults();
+        }
       }, 180);
     } else {
       setSuggestions([]);
       setIsSearching(false);
+      if (zipReps !== null) clearZipResults();
     }
     return () => { if (searchTimer.current) clearTimeout(searchTimer.current); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  // Trigger ZIP lookup after user stops typing (debounced 400ms)
+  useEffect(() => {
+    if (!isZipCode(query)) return;
+    if (query === lastSearchedZip) return; // don't re-fetch same zip
+
+    if (zipTimer.current) clearTimeout(zipTimer.current);
+    zipTimer.current = setTimeout(async () => {
+      setZipLoading(true);
+      setZipReps(null);
+      setZipError(false);
+
+      const result = await fetchRepsByZip(query);
+      setLastSearchedZip(query);
+
+      if (result.fallback) {
+        setZipError(true);
+        setZipReps([]);
+      } else {
+        const enriched = enrichRepsWithVerdicts(result.reps, financeMap);
+        setZipReps(enriched);
+        setZipState(result.state ?? null);
+      }
+      setZipLoading(false);
+    }, 400);
+
+    return () => { if (zipTimer.current) clearTimeout(zipTimer.current); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (query.trim()) {
-      router.push(`/congress?search=${encodeURIComponent(query.trim())}`);
+    const q = query.trim();
+    if (!q) return;
+
+    if (isZipCode(q) && zipError) {
+      // Fallback: route to congress search
+      router.push(`/congress?search=${encodeURIComponent(q)}`);
+    } else if (!isZipCode(q)) {
+      router.push(`/congress?search=${encodeURIComponent(q)}`);
     }
+    // If ZIP and results are shown, form submit does nothing extra
   };
 
   const handleSelect = (rep: typeof NOTABLE_REPS[0]) => {
     router.push(`/rep/${rep.id}`);
   };
 
-  const showSuggestions = isFocused && suggestions.length > 0;
+  const showNameSuggestions = isFocused && suggestions.length > 0 && !isZipCode(query);
+  const showZipPanel = isZipCode(query) && (zipLoading || zipReps !== null || zipError);
 
   return (
     <div className={`relative ${className}`}>
@@ -93,13 +193,13 @@ export default function RepSearch({
         {/* Outer wrap — animated on focus */}
         <div
           className={`search-wrap ${isFocused ? 'search-focused' : ''}`}
-          style={{ borderRadius: showSuggestions ? '4px 4px 0 0' : '4px', position: 'relative' }}
+          style={{ borderRadius: showNameSuggestions || showZipPanel ? '4px 4px 0 0' : '4px', position: 'relative' }}
         >
           {/* Scanning animation overlay — only while typing */}
           {isSearching && isFocused && (
             <span
               className="search-scanner"
-              style={{ borderRadius: showSuggestions ? '4px 4px 0 0' : '4px', zIndex: 1 }}
+              style={{ borderRadius: showNameSuggestions ? '4px 4px 0 0' : '4px', zIndex: 1 }}
               aria-hidden="true"
             />
           )}
@@ -108,14 +208,14 @@ export default function RepSearch({
             className={`relative flex items-center border-2 bg-white overflow-hidden ${
               isFocused ? 'border-teal-600' : 'border-slate-900'
             } transition-colors duration-200`}
-            style={{ borderRadius: showSuggestions ? '4px 4px 0 0' : '4px' }}
+            style={{ borderRadius: showNameSuggestions || showZipPanel ? '4px 4px 0 0' : '4px' }}
           >
-            {/* Search icon */}
+            {/* Search icon — show location pin for ZIP */}
             <div
               className="pl-4 flex-shrink-0 transition-colors duration-200"
               style={{ color: isFocused ? '#0F766E' : '#64748B' }}
             >
-              <SearchIcon size={size} />
+              {isZipCode(query) ? <LocationPinIcon /> : <SearchIcon size={size} />}
             </div>
 
             <input
@@ -130,8 +230,10 @@ export default function RepSearch({
                 size === 'large' ? 'py-4 text-lg' : 'py-3 text-base'
               }`}
               style={{ fontFamily: "'Source Sans 3', sans-serif" }}
-              aria-label="Search for a representative"
+              aria-label="Search for a representative or enter your ZIP code"
               autoComplete="off"
+              inputMode={isZipCode(query.slice(0, 5)) || query.length <= 5 ? 'numeric' : 'text'}
+              maxLength={100}
             />
 
             <button
@@ -148,8 +250,8 @@ export default function RepSearch({
           </div>
         </div>
 
-        {/* Suggestions dropdown */}
-        {showSuggestions && (
+        {/* Name suggestions dropdown */}
+        {showNameSuggestions && (
           <div
             className="absolute left-0 right-0 z-50 bg-white border-2 border-t-0 border-teal-600 overflow-hidden"
             style={{ borderRadius: '0 0 4px 4px', boxShadow: '0 8px 24px rgb(0 0 0 / 0.12)' }}
@@ -224,6 +326,159 @@ export default function RepSearch({
                   Scanning...
                 </span>
               )}
+            </div>
+          </div>
+        )}
+
+        {/* ZIP lookup panel */}
+        {showZipPanel && (
+          <div
+            className="absolute left-0 right-0 z-50 bg-white border-2 border-t-0 border-teal-600 overflow-hidden"
+            style={{ borderRadius: '0 0 4px 4px', boxShadow: '0 8px 24px rgb(0 0 0 / 0.12)' }}
+            role="region"
+            aria-label="Your representatives"
+          >
+            {/* Panel header */}
+            <div
+              className="px-4 py-2.5 border-b border-slate-100 flex items-center justify-between"
+              style={{ backgroundColor: '#F0FDF4' }}
+            >
+              <div className="flex items-center gap-2">
+                <LocationPinIcon />
+                <span
+                  className="text-sm font-semibold text-teal-800"
+                  style={{ fontFamily: "'Source Sans 3', sans-serif" }}
+                >
+                  Your Representatives — ZIP {query}
+                  {zipState && ` · ${zipState}`}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={clearZipResults}
+                className="text-slate-400 hover:text-slate-600 transition-colors text-lg leading-none"
+                aria-label="Close representatives panel"
+              >
+                ×
+              </button>
+            </div>
+
+            {/* Loading state */}
+            {zipLoading && <LoadingSpinner />}
+
+            {/* Error / fallback */}
+            {!zipLoading && zipError && (
+              <div className="px-4 py-4 text-center">
+                <p className="text-sm text-slate-600 mb-2" style={{ fontFamily: "'Source Sans 3', sans-serif" }}>
+                  Couldn&apos;t look up reps for this ZIP automatically.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => router.push(`/congress?search=${encodeURIComponent(query)}`)}
+                  className="text-sm font-semibold text-teal-700 hover:text-teal-900 underline underline-offset-2"
+                  style={{ fontFamily: "'Source Sans 3', sans-serif" }}
+                >
+                  Search congress page for {query} →
+                </button>
+              </div>
+            )}
+
+            {/* Results */}
+            {!zipLoading && zipReps && zipReps.length > 0 && (
+              <div>
+                {zipReps.map((rep) => {
+                  const ps = PARTY_STYLES[rep.party] ?? PARTY_STYLES['I'];
+                  return (
+                    <a
+                      key={rep.bioguide_id}
+                      href={rep.profile_url}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors border-b border-slate-100 last:border-0 group no-underline"
+                    >
+                      {/* Photo */}
+                      <div
+                        className="flex-shrink-0 w-10 h-10 rounded-sm bg-slate-200 overflow-hidden"
+                        style={{ border: '1px solid #E2E8F0' }}
+                      >
+                        {rep.photo_url ? (
+                          <img
+                            src={rep.photo_url}
+                            alt=""
+                            aria-hidden="true"
+                            className="w-full h-full object-cover"
+                            onError={e => {
+                              (e.target as HTMLImageElement).style.display = 'none';
+                            }}
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-slate-400 text-lg">
+                            {rep.display_name[0] ?? '?'}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Name + role */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span
+                            className="text-sm font-semibold text-slate-900 group-hover:text-teal-700 transition-colors truncate"
+                            style={{ fontFamily: "'Source Sans 3', sans-serif" }}
+                          >
+                            {rep.display_name}
+                          </span>
+                          {/* Party badge */}
+                          <span
+                            className="flex-shrink-0 text-xs font-bold px-1.5 py-0.5 rounded-sm"
+                            style={{
+                              fontFamily: "'JetBrains Mono', monospace",
+                              backgroundColor: ps.bg,
+                              color: ps.text,
+                              fontSize: '0.625rem',
+                              letterSpacing: '0.05em',
+                            }}
+                          >
+                            {ps.label}
+                          </span>
+                        </div>
+                        <div
+                          className="text-xs text-slate-500"
+                          style={{ fontFamily: "'Source Sans 3', sans-serif" }}
+                        >
+                          {rep.chamber === 'house'
+                            ? `Representative · ${rep.state}-${rep.district}`
+                            : `Senator · ${rep.state}`}
+                        </div>
+                      </div>
+
+                      {/* Verdict badge */}
+                      <div className="flex-shrink-0 flex items-center gap-2">
+                        {rep.pac_pct !== null && (
+                          <RepVerdictBadge
+                            pacPct={rep.pac_pct}
+                            className="text-xs px-2 py-0.5"
+                          />
+                        )}
+                        <ExternalLinkIcon />
+                      </div>
+                    </a>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* No results */}
+            {!zipLoading && zipReps && zipReps.length === 0 && !zipError && (
+              <div className="px-4 py-4 text-center text-sm text-slate-500" style={{ fontFamily: "'Source Sans 3', sans-serif" }}>
+                No representatives found for this ZIP code.
+              </div>
+            )}
+
+            {/* Footer */}
+            <div
+              className="px-4 py-2 text-xs bg-slate-50 flex items-center justify-between"
+              style={{ fontFamily: "'Source Sans 3', sans-serif", color: '#94A3B8' }}
+            >
+              <span>Click a rep to view their full accountability profile</span>
+              <span className="text-teal-600 font-medium">ZIP Lookup</span>
             </div>
           </div>
         )}

--- a/src/lib/find-reps.test.ts
+++ b/src/lib/find-reps.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for ZIP → Find Your Reps feature (issue #128)
+ * Tests run BEFORE implementation (TDD).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ZIP_REGEX,
+  isZipCode,
+  mapPartyCode,
+  enrichRepsWithVerdicts,
+  fetchRepsByZip,
+  type FindRepsResult,
+  type RawRep,
+} from './find-reps';
+
+// ─── ZIP Detection ───────────────────────────────────────────────────────────
+
+describe('ZIP_REGEX', () => {
+  it('matches a standard 5-digit ZIP', () => {
+    expect(ZIP_REGEX.test('10001')).toBe(true);
+    expect(ZIP_REGEX.test('90210')).toBe(true);
+    expect(ZIP_REGEX.test('00501')).toBe(true);
+  });
+
+  it('does not match partial ZIPs or non-numeric strings', () => {
+    expect(ZIP_REGEX.test('1234')).toBe(false);   // too short
+    expect(ZIP_REGEX.test('123456')).toBe(false);  // too long
+    expect(ZIP_REGEX.test('abcde')).toBe(false);   // letters
+    expect(ZIP_REGEX.test('1000a')).toBe(false);   // mixed
+    expect(ZIP_REGEX.test('')).toBe(false);        // empty
+    expect(ZIP_REGEX.test('10001-1234')).toBe(false); // ZIP+4 not supported
+  });
+});
+
+describe('isZipCode', () => {
+  it('returns true for valid 5-digit ZIPs', () => {
+    expect(isZipCode('10001')).toBe(true);
+    expect(isZipCode('90210')).toBe(true);
+  });
+
+  it('returns false for non-ZIP strings', () => {
+    expect(isZipCode('nancy pelosi')).toBe(false);
+    expect(isZipCode('CA')).toBe(false);
+    expect(isZipCode('')).toBe(false);
+  });
+});
+
+// ─── Party mapping ───────────────────────────────────────────────────────────
+
+describe('mapPartyCode', () => {
+  it('maps Democratic to D', () => {
+    expect(mapPartyCode('Democratic')).toBe('D');
+    expect(mapPartyCode('democrat')).toBe('D');
+  });
+
+  it('maps Republican to R', () => {
+    expect(mapPartyCode('Republican')).toBe('R');
+    expect(mapPartyCode('REPUBLICAN')).toBe('R');
+  });
+
+  it('maps unknown parties to I', () => {
+    expect(mapPartyCode('Independent')).toBe('I');
+    expect(mapPartyCode('Green')).toBe('I');
+    expect(mapPartyCode('')).toBe('I');
+    expect(mapPartyCode(undefined)).toBe('I');
+  });
+});
+
+// ─── Result mapping / enrichment ─────────────────────────────────────────────
+
+describe('enrichRepsWithVerdicts', () => {
+  const mockFinance: Record<string, { pac_percentage: number }> = {
+    S000148: { pac_percentage: 15 },   // constituent
+    C001098: { pac_percentage: 65 },   // captured
+    O000172: { pac_percentage: 40 },   // mixed
+  };
+
+  const reps: RawRep[] = [
+    { bioguide_id: 'S000148', name: 'Schumer, Charles E.', party: 'D', state: 'NY', chamber: 'senate', district: null, photo_url: null },
+    { bioguide_id: 'C001098', name: 'Cruz, Ted', party: 'R', state: 'TX', chamber: 'senate', district: null, photo_url: null },
+    { bioguide_id: 'O000172', name: 'Ocasio-Cortez, Alexandria', party: 'D', state: 'NY', chamber: 'house', district: '14', photo_url: null },
+    { bioguide_id: 'UNKNOWN', name: 'Ghost, Joe', party: 'I', state: 'XX', chamber: 'house', district: '1', photo_url: null },
+  ];
+
+  it('attaches pac_percentage from finance data by bioguide_id', () => {
+    const enriched = enrichRepsWithVerdicts(reps, mockFinance);
+    expect(enriched[0].pac_pct).toBe(15);
+    expect(enriched[1].pac_pct).toBe(65);
+    expect(enriched[2].pac_pct).toBe(40);
+  });
+
+  it('returns null pac_pct when bioguide_id not in finance data', () => {
+    const enriched = enrichRepsWithVerdicts(reps, mockFinance);
+    expect(enriched[3].pac_pct).toBeNull();
+  });
+
+  it('returns same number of reps as input', () => {
+    const enriched = enrichRepsWithVerdicts(reps, mockFinance);
+    expect(enriched).toHaveLength(4);
+  });
+
+  it('preserves all original rep fields', () => {
+    const enriched = enrichRepsWithVerdicts(reps, mockFinance);
+    expect(enriched[0].bioguide_id).toBe('S000148');
+    expect(enriched[0].chamber).toBe('senate');
+    expect(enriched[0].state).toBe('NY');
+  });
+});
+
+// ─── API fetch / fallback ─────────────────────────────────────────────────────
+
+describe('fetchRepsByZip', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls /api/find-reps with the provided ZIP', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        reps: [
+          { bioguide_id: 'S000148', name: 'Schumer, Charles E.', party: 'D', state: 'NY', chamber: 'senate', district: null, photo_url: null },
+        ],
+        state: 'NY',
+        district: '12',
+      }),
+    } as Response);
+
+    const result = await fetchRepsByZip('10001');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/find-reps?zip=10001');
+    expect(result.fallback).toBe(false);
+    expect(result.reps).toHaveLength(1);
+    expect(result.reps[0].bioguide_id).toBe('S000148');
+  });
+
+  it('returns fallback=true when API returns { fallback: true }', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ fallback: true }),
+    } as Response);
+
+    const result = await fetchRepsByZip('99999');
+    expect(result.fallback).toBe(true);
+    expect(result.reps).toHaveLength(0);
+  });
+
+  it('returns fallback=true when fetch throws (network error)', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await fetchRepsByZip('10001');
+    expect(result.fallback).toBe(true);
+    expect(result.reps).toHaveLength(0);
+  });
+
+  it('returns fallback=true when HTTP response is not ok', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Internal Server Error' }),
+    } as Response);
+
+    const result = await fetchRepsByZip('10001');
+    expect(result.fallback).toBe(true);
+    expect(result.reps).toHaveLength(0);
+  });
+});

--- a/src/lib/find-reps.ts
+++ b/src/lib/find-reps.ts
@@ -1,0 +1,111 @@
+/**
+ * find-reps.ts — ZIP code → congressional representatives lookup
+ * Issue #128
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RawRep {
+  bioguide_id: string;
+  name: string;
+  party: string;
+  state: string;
+  chamber: 'house' | 'senate';
+  district: string | null;
+  photo_url: string | null;
+}
+
+export interface EnrichedRep extends RawRep {
+  pac_pct: number | null;
+  display_name: string;  // "Last, First" → "First Last"
+  profile_url: string;
+}
+
+export interface FindRepsResult {
+  fallback: boolean;
+  reps: EnrichedRep[];
+  state?: string;
+  district?: string;
+}
+
+// ─── ZIP detection ────────────────────────────────────────────────────────────
+
+/** Matches exactly 5 consecutive digits — full string */
+export const ZIP_REGEX = /^\d{5}$/;
+
+export function isZipCode(query: string): boolean {
+  return ZIP_REGEX.test(query.trim());
+}
+
+// ─── Party mapping ────────────────────────────────────────────────────────────
+
+export function mapPartyCode(partyName: string | undefined): 'D' | 'R' | 'I' {
+  if (!partyName) return 'I';
+  const p = partyName.toLowerCase();
+  if (p.includes('democrat')) return 'D';
+  if (p.includes('republican')) return 'R';
+  return 'I';
+}
+
+// ─── Name formatting ──────────────────────────────────────────────────────────
+
+/** Convert "Last, First M." → "First Last" for display */
+export function formatRepName(apiName: string): string {
+  if (!apiName) return apiName;
+  const commaIdx = apiName.indexOf(',');
+  if (commaIdx === -1) return apiName;
+  const last = apiName.slice(0, commaIdx).trim();
+  const rest = apiName.slice(commaIdx + 1).trim();
+  // Take first token of rest (first name), skip suffixes
+  const first = rest.split(/\s+/)[0] ?? '';
+  return first ? `${first} ${last}` : last;
+}
+
+// ─── Enrichment ───────────────────────────────────────────────────────────────
+
+/**
+ * Match raw reps from the API against local finance data to produce verdict-ready results.
+ * @param reps Raw rep array from /api/find-reps
+ * @param financeData keyed by bioguide_id: { pac_percentage }
+ */
+export function enrichRepsWithVerdicts(
+  reps: RawRep[],
+  financeData: Record<string, { pac_percentage: number }>
+): EnrichedRep[] {
+  return reps.map((rep) => {
+    const finance = financeData[rep.bioguide_id];
+    return {
+      ...rep,
+      pac_pct: finance?.pac_percentage ?? null,
+      display_name: formatRepName(rep.name),
+      profile_url: `/rep/${rep.bioguide_id}`,
+    };
+  });
+}
+
+// ─── API fetch ────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch representatives for a given ZIP code from the CF Pages Function.
+ * Always resolves — returns { fallback: true } on any error.
+ */
+export async function fetchRepsByZip(zip: string): Promise<FindRepsResult> {
+  try {
+    const res = await fetch(`/api/find-reps?zip=${encodeURIComponent(zip)}`);
+    if (!res.ok) {
+      return { fallback: true, reps: [] };
+    }
+    const data = await res.json();
+    if (data.fallback) {
+      return { fallback: true, reps: [] };
+    }
+    return {
+      fallback: false,
+      reps: data.reps ?? [],
+      state: data.state,
+      district: data.district,
+    };
+  } catch {
+    return { fallback: true, reps: [] };
+  }
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #128 — ZIP code search to find your congressional representatives directly from the search bar.

## Changes

### `functions/api/find-reps.js` (new — Cloudflare Pages Function)
- Accepts `GET /api/find-reps?zip=XXXXX`
- **Pipeline:** `zippopotam.us` (lat/lng + state) → Census Geocoder (congressional district) → Congress.gov v3 (member lookup)
- Returns 1 House rep + 2 Senators with `bioguide_id`, `name`, `party`, `state`, `chamber`, `photo_url`
- Graceful fallback: returns `{ fallback: true }` on any API error or missing data
- `CONGRESS_API_KEY` env var set in Cloudflare Pages (both production + preview)

### `src/lib/find-reps.ts` (new — client utility)
- `ZIP_REGEX` / `isZipCode()` — ZIP detection
- `mapPartyCode()` — normalizes party names to D/R/I
- `enrichRepsWithVerdicts()` — matches `bioguide_id` against `finance.json` for PAC percentage
- `fetchRepsByZip()` — calls `/api/find-reps` with graceful fallback on any error

### `src/components/RepSearch.tsx` (updated)
- Detects `/^\d{5}$/` pattern on input
- Debounced ZIP lookup (400ms) triggers `/api/find-reps`
- Shows **"Your Representatives"** panel with:
  - Photo, name, party badge
  - `RepVerdictBadge` (PAC % from local finance data)
  - Direct profile links (`/rep/{bioguide_id}`)
- Fallback: routes to `/congress?search=ZIPCODE` if API unavailable
- Accessible: `role=region`, `aria-labels`, keyboard navigable

### `src/lib/find-reps.test.ts` (new — 15 tests, all passing)
- ZIP regex detection (valid/invalid patterns)
- `mapPartyCode` normalization
- `enrichRepsWithVerdicts` result mapping + bioguide matching
- `fetchRepsByZip` API call + all fallback scenarios

## Test Results
```
Test Files  68 passed (68)
Tests       767 passed (767)
```

Build: ✅ green

Closes #128