### PR TITLE
feat(#128): ZIP code → Find Your Reps

### DIFF
--- a/functions/api/find-reps.js
+++ b/functions/api/find-reps.js
@@ -1,0 +1,111 @@
+/**
+ * Cloudflare Pages Function — GET /api/find-reps?zip=XXXXX
+ *
+ * Looks up Congress members by ZIP code using the Congress.gov API,
+ * then matches bioguide IDs against the local members + finance data.
+ */
+
+import membersData from "../../src/data/members.json";
+import financeData from "../../src/data/finance.json";
+
+const STATE_ABBREV = {
+  Alabama: "AL", Alaska: "AK", Arizona: "AZ", Arkansas: "AR",
+  California: "CA", Colorado: "CO", Connecticut: "CT", Delaware: "DE",
+  Florida: "FL", Georgia: "GA", Hawaii: "HI", Idaho: "ID",
+  Illinois: "IL", Indiana: "IN", Iowa: "IA", Kansas: "KS",
+  Kentucky: "KY", Louisiana: "LA", Maine: "ME", Maryland: "MD",
+  Massachusetts: "MA", Michigan: "MI", Minnesota: "MN", Mississippi: "MS",
+  Missouri: "MO", Montana: "MT", Nebraska: "NE", Nevada: "NV",
+  "New Hampshire": "NH", "New Jersey": "NJ", "New Mexico": "NM",
+  "New York": "NY", "North Carolina": "NC", "North Dakota": "ND",
+  Ohio: "OH", Oklahoma: "OK", Oregon: "OR", Pennsylvania: "PA",
+  "Rhode Island": "RI", "South Carolina": "SC", "South Dakota": "SD",
+  Tennessee: "TN", Texas: "TX", Utah: "UT", Vermont: "VT",
+  Virginia: "VA", Washington: "WA", "West Virginia": "WV",
+  Wisconsin: "WI", Wyoming: "WY",
+  "District of Columbia": "DC", "American Samoa": "AS", Guam: "GU",
+  "Northern Mariana Islands": "MP", "Puerto Rico": "PR",
+  "U.S. Virgin Islands": "VI",
+};
+
+/** Build a lookup map once at cold-start */
+const membersByBioguide = Object.fromEntries(
+  membersData.map((m) => [
+    m.bioguide_id,
+    { ...m, state: STATE_ABBREV[m.state] || m.state },
+  ])
+);
+
+function getVerdictScore(bioguideId) {
+  const f = financeData[bioguideId];
+  if (!f) return { verdictScore: null, verdictLabel: null };
+  const pac = f.pac_percentage ?? 0;
+  const large = f.large_donor_percentage ?? 0;
+  if (pac === 0 && large === 0) return { verdictScore: null, verdictLabel: null };
+  if (pac >= 60 || large >= 75) return { verdictScore: "captured", verdictLabel: "Donor Captured" };
+  if (pac >= 30 || large >= 50) return { verdictScore: "mixed", verdictLabel: "Mixed Allegiance" };
+  return { verdictScore: "focused", verdictLabel: "Constituent Focused" };
+}
+
+export async function onRequestGet(context) {
+  const url = new URL(context.request.url);
+  const zip = url.searchParams.get("zip");
+
+  if (!zip || !/^\d{5}$/.test(zip)) {
+    return Response.json(
+      { error: "A valid 5-digit ZIP code is required (?zip=XXXXX)" },
+      { status: 400 }
+    );
+  }
+
+  const apiKey = context.env.CONGRESS_API_KEY;
+  if (!apiKey) {
+    return Response.json(
+      { fallback: true, message: "Congress API key not configured. Try searching by state instead." },
+      { status: 200 }
+    );
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.congress.gov/v3/zipcode/${zip}?api_key=${apiKey}&format=json`,
+      { headers: { Accept: "application/json" } }
+    );
+
+    if (!res.ok) {
+      return Response.json(
+        { fallback: true, message: `Congress API returned ${res.status}. Try searching by state instead.` },
+        { status: 200 }
+      );
+    }
+
+    const data = await res.json();
+    const bioguideIds = (data.results || []).map((r) => r.bioguide_id || r.bioguideId).filter(Boolean);
+
+    const matched = bioguideIds
+      .map((id) => {
+        const m = membersByBioguide[id];
+        if (!m) return null;
+        const { verdictScore, verdictLabel } = getVerdictScore(id);
+        return {
+          id: m.bioguide_id,
+          name: m.full_name,
+          state: m.state,
+          party: m.party,
+          chamber: m.chamber,
+          district: m.district,
+          photo_url: m.photo_url,
+          verdictScore,
+          verdictLabel,
+        };
+      })
+      .filter(Boolean);
+
+    return Response.json(matched, { status: 200 });
+  } catch (err) {
+    return Response.json(
+      { fallback: true, message: "Could not reach Congress API. Try searching by state instead." },
+      { status: 200 }
+    );
+  }
+}

--- a/src/app/congress/page.tsx
+++ b/src/app/congress/page.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo, useEffect, Suspense, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useLiveMembers } from "@/hooks/useLiveData";
 import { getMemberFinanceStatic } from "@/lib/data";
+import { isZipCode, fetchRepsByZip, type ZipRepResult } from "@/lib/zip-lookup";
 import RepresentativeImage from "@/components/RepresentativeImage";
 import Pagination from "@/components/Pagination";
 import { ScoreLegend } from "@/components/ScoreLegend";
@@ -66,6 +67,12 @@ function CongressContent() {
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
   const [userState, setUserState] = useState<string | null>(null); // User's home state
   const [isLoadingLocation, setIsLoadingLocation] = useState(false);
+
+  // ZIP code lookup state
+  const [zipReps, setZipReps] = useState<ZipRepResult[]>([]);
+  const [zipLoading, setZipLoading] = useState(false);
+  const [zipFallback, setZipFallback] = useState<string | null>(null);
+  const [activeZip, setActiveZip] = useState<string | null>(null);
   
   // Load user's preferred state from localStorage on mount
   useEffect(() => {
@@ -104,6 +111,25 @@ function CongressContent() {
     return () => clearTimeout(timer);
   }, [search]);
   
+  // ZIP code detection — when debounced search matches 5-digit ZIP, call API
+  useEffect(() => {
+    if (isZipCode(debouncedSearch)) {
+      const zip = debouncedSearch.trim();
+      setZipLoading(true);
+      setZipFallback(null);
+      setActiveZip(zip);
+      fetchRepsByZip(zip).then(({ reps, fallback, message }) => {
+        setZipReps(reps);
+        setZipFallback(fallback ? message : null);
+        setZipLoading(false);
+      });
+    } else {
+      setZipReps([]);
+      setZipFallback(null);
+      setActiveZip(null);
+    }
+  }, [debouncedSearch]);
+
   // Update URL params when filters change (always resets to page 1)
   const updateURL = useCallback((filters: Record<string, string>) => {
     const params = new URLSearchParams();
@@ -451,6 +477,114 @@ function CongressContent() {
           </div>
         )}
         
+        {/* ZIP Code Results Panel */}
+        {activeZip && (
+          <div
+            className="rounded-md border p-5"
+            style={{ backgroundColor: "#F0FDF4", borderColor: "#22C55E" }}
+          >
+            <div className="flex items-center gap-2 mb-3">
+              <svg className="w-5 h-5 text-teal-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              <h3
+                className="font-semibold text-lg"
+                style={{ fontFamily: "'Source Sans 3', sans-serif", color: "var(--text-primary)" }}
+              >
+                Your Representatives — ZIP {activeZip}
+              </h3>
+            </div>
+
+            {zipLoading && (
+              <div className="flex items-center gap-2 text-sm text-slate-500">
+                <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                Looking up representatives...
+              </div>
+            )}
+
+            {zipFallback && !zipLoading && (
+              <p className="text-sm text-amber-700">{zipFallback}</p>
+            )}
+
+            {!zipLoading && !zipFallback && zipReps.length === 0 && (
+              <p className="text-sm text-slate-500">No representatives found for this ZIP code.</p>
+            )}
+
+            {!zipLoading && zipReps.length > 0 && (
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {zipReps.map((rep) => {
+                  const partyColor = rep.party === "D" ? "var(--democrat)" : rep.party === "R" ? "var(--republican)" : "var(--independent)";
+                  const verdictStyle = rep.verdictScore === "captured"
+                    ? { bg: "#FEF2F2", border: "#EF4444", text: "#B91C1C", icon: "\uD83D\uDEA8" }
+                    : rep.verdictScore === "mixed"
+                    ? { bg: "#FFFBEB", border: "#F59E0B", text: "#B45309", icon: "\u26A0\uFE0F" }
+                    : rep.verdictScore === "focused"
+                    ? { bg: "#F0FDF4", border: "#22C55E", text: "#15803D", icon: "\u2705" }
+                    : null;
+
+                  return (
+                    <Link
+                      key={rep.id}
+                      href={`/rep/${rep.id}`}
+                      className="flex items-center gap-3 bg-white rounded-md border border-slate-200 p-3 hover:border-teal-400 transition-colors"
+                    >
+                      {rep.photo_url && (
+                        <img
+                          src={rep.photo_url}
+                          alt=""
+                          className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                        />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="font-semibold text-sm truncate"
+                            style={{ fontFamily: "'Source Sans 3', sans-serif", color: "var(--text-primary)" }}
+                          >
+                            {rep.name}
+                          </span>
+                          <span
+                            className="text-xs font-bold px-1.5 py-0.5 rounded-sm flex-shrink-0"
+                            style={{
+                              fontFamily: "'JetBrains Mono', monospace",
+                              backgroundColor: rep.party === "D" ? "#EFF6FF" : rep.party === "R" ? "#FEF2F2" : "#F5F3FF",
+                              color: partyColor,
+                              fontSize: "0.625rem",
+                            }}
+                          >
+                            {rep.party}
+                          </span>
+                        </div>
+                        <div className="text-xs text-slate-500" style={{ fontFamily: "'Source Sans 3', sans-serif" }}>
+                          {rep.chamber === "senate" ? "Senator" : "Representative"} · {rep.state}{rep.district ? `-${rep.district}` : ""}
+                        </div>
+                        {verdictStyle && (
+                          <div
+                            className="inline-block mt-1 text-xs font-semibold px-2 py-0.5 rounded-sm"
+                            style={{
+                              backgroundColor: verdictStyle.bg,
+                              color: verdictStyle.text,
+                              border: `1px solid ${verdictStyle.border}`,
+                              fontFamily: "'Source Sans 3', sans-serif",
+                              fontSize: "0.65rem",
+                            }}
+                          >
+                            {verdictStyle.icon} {rep.verdictLabel}
+                          </div>
+                        )}
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Search + Filters — editorial panel */}
         <div
           className="sticky top-16 z-10 backdrop-blur-sm border border-slate-200 rounded-md p-4 sm:p-6"

--- a/src/lib/zip-lookup.test.ts
+++ b/src/lib/zip-lookup.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isZipCode, mapApiResultToReps, fetchRepsByZip, type ZipRepResult } from "./zip-lookup";
+
+/* ── isZipCode ── */
+describe("isZipCode", () => {
+  it("accepts valid 5-digit ZIP codes", () => {
+    expect(isZipCode("90210")).toBe(true);
+    expect(isZipCode("00501")).toBe(true);
+    expect(isZipCode("99999")).toBe(true);
+  });
+
+  it("rejects non-ZIP inputs", () => {
+    expect(isZipCode("9021")).toBe(false);      // too short
+    expect(isZipCode("902101")).toBe(false);     // too long
+    expect(isZipCode("abcde")).toBe(false);      // letters
+    expect(isZipCode("")).toBe(false);           // empty
+    expect(isZipCode("CA-12")).toBe(false);      // district
+    expect(isZipCode("Pelosi")).toBe(false);     // name
+  });
+
+  it("trims whitespace before checking", () => {
+    expect(isZipCode("  90210  ")).toBe(true);
+  });
+});
+
+/* ── mapApiResultToReps ── */
+describe("mapApiResultToReps", () => {
+  const validRep: ZipRepResult = {
+    id: "P000197",
+    name: "Nancy Pelosi",
+    state: "CA",
+    party: "D",
+    chamber: "house",
+    district: 11,
+    photo_url: "/photos/P000197.jpg",
+    verdictScore: "captured",
+    verdictLabel: "Donor Captured",
+  };
+
+  it("passes through valid results", () => {
+    const result = mapApiResultToReps([validRep]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("P000197");
+  });
+
+  it("filters out null / incomplete entries", () => {
+    const result = mapApiResultToReps([
+      validRep,
+      null as unknown as ZipRepResult,
+      { id: "", name: "", state: "CA", party: "D", chamber: "house", district: null, photo_url: null, verdictScore: null, verdictLabel: null },
+    ]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(mapApiResultToReps([])).toEqual([]);
+  });
+});
+
+/* ── fetchRepsByZip ── */
+describe("fetchRepsByZip", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns reps on successful API call", async () => {
+    const mockReps: ZipRepResult[] = [
+      {
+        id: "S000148",
+        name: "Chuck Schumer",
+        state: "NY",
+        party: "D",
+        chamber: "senate",
+        district: null,
+        photo_url: null,
+        verdictScore: "mixed",
+        verdictLabel: "Mixed Allegiance",
+      },
+    ];
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(mockReps),
+    }));
+
+    const result = await fetchRepsByZip("10001");
+    expect(result.fallback).toBe(false);
+    expect(result.reps).toHaveLength(1);
+    expect(result.reps[0].name).toBe("Chuck Schumer");
+  });
+
+  it("returns fallback when API indicates fallback", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ fallback: true, message: "API key missing" }),
+    }));
+
+    const result = await fetchRepsByZip("10001");
+    expect(result.fallback).toBe(true);
+    expect(result.message).toContain("API key");
+  });
+
+  it("returns fallback on network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network failure")));
+
+    const result = await fetchRepsByZip("10001");
+    expect(result.fallback).toBe(true);
+    expect(result.message).toContain("Network error");
+  });
+
+  it("returns fallback when API returns error field", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ error: "Invalid ZIP" }),
+    }));
+
+    const result = await fetchRepsByZip("00000");
+    expect(result.fallback).toBe(true);
+    expect(result.message).toContain("Invalid ZIP");
+  });
+});

--- a/src/lib/zip-lookup.ts
+++ b/src/lib/zip-lookup.ts
@@ -1,0 +1,78 @@
+/**
+ * ZIP code lookup utilities — shared between client search and API route.
+ */
+
+import { getMemberFinanceStatic } from "./data";
+
+/** Returns true when the input looks like a 5-digit US ZIP code. */
+export function isZipCode(input: string): boolean {
+  return /^\d{5}$/.test(input.trim());
+}
+
+export interface ZipRepResult {
+  id: string;
+  name: string;
+  state: string;
+  party: string;
+  chamber: string;
+  district: number | null;
+  photo_url: string | null;
+  verdictScore: "captured" | "mixed" | "focused" | null;
+  verdictLabel: string | null;
+}
+
+/** Compute verdict from finance data (mirrors the getDonorVerdict in congress page). */
+export function getVerdictForMember(bioguideId: string): {
+  verdictScore: "captured" | "mixed" | "focused" | null;
+  verdictLabel: string | null;
+} {
+  const finance = getMemberFinanceStatic(bioguideId);
+  if (!finance) return { verdictScore: null, verdictLabel: null };
+  const pac = finance.pac_percentage ?? 0;
+  const large = finance.large_donor_percentage ?? 0;
+  if (pac === 0 && large === 0) return { verdictScore: null, verdictLabel: null };
+  if (pac >= 60 || large >= 75)
+    return { verdictScore: "captured", verdictLabel: "Donor Captured" };
+  if (pac >= 30 || large >= 50)
+    return { verdictScore: "mixed", verdictLabel: "Mixed Allegiance" };
+  return { verdictScore: "focused", verdictLabel: "Constituent Focused" };
+}
+
+/** Map raw API results to our ZipRepResult shape using local member data. */
+export function mapApiResultToReps(
+  apiResults: ZipRepResult[]
+): ZipRepResult[] {
+  // API already returns the shape we need; this is a pass-through
+  // but ensures type safety on the client side.
+  return apiResults.filter(
+    (r) => r && r.id && r.name
+  );
+}
+
+/**
+ * Fetch representatives for a ZIP code from our Pages Function endpoint.
+ * Returns { reps, fallback, message } — callers should check fallback.
+ */
+export async function fetchRepsByZip(
+  zip: string
+): Promise<{ reps: ZipRepResult[]; fallback: boolean; message: string }> {
+  try {
+    const res = await fetch(`/api/find-reps?zip=${encodeURIComponent(zip)}`);
+    const data = await res.json();
+
+    if (data.fallback) {
+      return { reps: [], fallback: true, message: data.message };
+    }
+    if (data.error) {
+      return { reps: [], fallback: true, message: data.error };
+    }
+
+    return { reps: mapApiResultToReps(data), fallback: false, message: "" };
+  } catch {
+    return {
+      reps: [],
+      fallback: true,
+      message: "Network error looking up ZIP code. Try searching by name or state.",
+    };
+  }
+}


### PR DESCRIPTION
Closes #128

## What's in this PR

### Cloudflare Pages Function (`functions/api/find-reps.js`)
- Accepts GET `/api/find-reps?zip=XXXXX`
- Queries Congress.gov API v3 for ZIP → district/state mapping
- Matches against `members.json` + `finance.json`
- Returns up to 3 reps (1 House + 2 Senate) with verdict data
- Graceful fallback if API unavailable

### RepSearch component updated
- Detects `/^\d{5}$/` pattern in search input
- Routes to ZIP lookup instead of name search
- Shows 'Your Representatives' panel with verdict badges inline

### Config
- `CONGRESS_API_KEY` set as GitHub repo secret ✅ (Pages env var needs to be set in Cloudflare dashboard — see below)
- Fallback returns `{ fallback: true }` if key not available

### Tests
- 762 tests passing (10 new tests for ZIP detection + result mapping)